### PR TITLE
fix(lint): Address QF1008

### DIFF
--- a/relay/ledger.go
+++ b/relay/ledger.go
@@ -96,7 +96,7 @@ func (l *Ledger) RecordOpenEvent(req *http.Request) {
 	hash.Write([]byte(req.Proto))
 	hash.Write([]byte(req.Method))
 	hash.Write([]byte(req.Host))
-	ent.LedgerEntry.Payload.Hash = base64.StdEncoding.EncodeToString(hash.Sum(nil))
+	ent.Payload.Hash = base64.StdEncoding.EncodeToString(hash.Sum(nil))
 
 	l.opens <- ent
 }
@@ -129,7 +129,7 @@ func (l *Ledger) RecordCloseEvent(res *http.Response) {
 	hash.Write([]byte(res.Request.Method))
 	hash.Write([]byte(res.Request.Host))
 	hash.Write([]byte(body))
-	ent.LedgerEntry.Payload.Hash = base64.StdEncoding.EncodeToString(hash.Sum(nil))
+	ent.Payload.Hash = base64.StdEncoding.EncodeToString(hash.Sum(nil))
 
 	l.closes <- ent
 }
@@ -141,21 +141,21 @@ func (l *Ledger) Loop() {
 		case open, more := <-l.opens:
 			if more {
 				l.writeOpen(open, lastsig)
-				lastsig = open.LedgerEntry.Signature
+				lastsig = open.Signature
 			} else {
 				l.done <- true
 			}
 		case ckp, more := <-l.checkpoints:
 			if more {
 				l.writeCheckpoint(ckp, lastsig)
-				lastsig = ckp.LedgerEntry.Signature
+				lastsig = ckp.Signature
 			} else {
 				l.done <- true
 			}
 		case close, more := <-l.closes:
 			if more {
 				l.writeClose(close, lastsig)
-				lastsig = close.LedgerEntry.Signature
+				lastsig = close.Signature
 			} else {
 				l.done <- true
 			}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Seeing lint failures after making some version updates

https://github.com/buildwarden/buildwarden/actions/runs/17663082027/job/50199793129

> QF1008: could remove embedded field "LedgerEntry" from selector (staticcheck)

https://staticcheck.dev/docs/checks#QF1008

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
