### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-tidy.yml
+++ b/.github/workflows/auto-tidy.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   auto-tidy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/buildwarden/buildwarden/security/code-scanning/1](https://github.com/buildwarden/buildwarden/security/code-scanning/1)

To fix this problem, we should add an explicit `permissions:` block either at the root of the workflow file (before `jobs:`) or within the `auto-tidy` job block. Since this workflow only has a single job and the automated commit step needs permission to write to repository contents, we should set `contents: write` to enable committing changes with `GITHUB_TOKEN`. Adding the block to the job itself (line 8, directly under `auto-tidy:` and before `runs-on:`) is the best way to limit permissions specifically to the job. Alternatively, adding at the root applies to all jobs. In this case, both would fix, but job-level is most precise. Insert:

```yaml
permissions:
  contents: write
```

above `runs-on:` in the `auto-tidy` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
