### PR TITLE
Hardened network isolation using rootless DIND

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,4 +26,4 @@ jobs:
       - uses: actions/setup-go@v4
         with: { go-version: 'v1.25.1', check-latest: true }
       - run: ./build.sh build
-      - run: warden --help
+      - run: ./warden --help

--- a/buildctx/Dockerfile.simple
+++ b/buildctx/Dockerfile.simple
@@ -1,4 +1,19 @@
-FROM alpine
+FROM python:3.12-slim
 
-RUN apk add py3-pip
-RUN python3 -m venv /venv && /venv/bin/pip install numpy
+RUN apt-get update && apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip build
+
+# Download the latest requests source distribution and build a wheel
+RUN pip download --no-binary :all: --no-deps requests -d /tmp/sdist && \
+    tar xzf /tmp/sdist/requests-*.tar.gz -C /tmp && \
+    cd /tmp/requests-*/ && \
+    python -m build --wheel && \
+    cp dist/requests-*.whl /tmp/
+
+# Post the built wheel as an artifact
+RUN WHEEL=$(ls /tmp/requests-*.whl) && \
+    curl -fsSL -X POST --data-binary @"$WHEEL" \
+        "http://artifacts/$(basename $WHEEL)" && \
+    echo "Artifact posted: $(basename $WHEEL)"

--- a/cmd/ledger-inspect/main.go
+++ b/cmd/ledger-inspect/main.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -44,13 +45,30 @@ type PayloadRecord struct {
 	Hashes map[string]string `json:"hashes"`
 }
 
+// channel tracks a complete request lifecycle.
+type channel struct {
+	open        LedgerEntry
+	checkpoints []LedgerEntry
+	close       *LedgerEntry
+	valid       bool // all entries in this channel verified
+}
+
+var verbosity int
+
 func main() { //nolint:gocyclo
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "usage: ledger-inspect <ledger-file>\n")
+	flag.IntVar(&verbosity, "v", 0, "verbosity: 0=compact, 1=tree, 2=json")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: ledger-inspect [-v N] <ledger-file>\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		flag.Usage()
 		os.Exit(1)
 	}
 
-	f, err := os.Open(os.Args[1])
+	f, err := os.Open(flag.Arg(0))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
@@ -60,7 +78,6 @@ func main() { //nolint:gocyclo
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
 
-	// Parse header
 	if !scanner.Scan() {
 		fmt.Fprintf(os.Stderr, "error: empty ledger\n")
 		os.Exit(1)
@@ -72,22 +89,14 @@ func main() { //nolint:gocyclo
 		os.Exit(1)
 	}
 
-	// Extract public key from payload
 	verifier := reconstructVerifier(header)
-
-	// Verify header signature
-	headerValid := false
-	if verifier != nil {
-		headerValid = verifyHeader(header, verifier)
-	}
-
+	headerValid := verifier != nil && verifyHeader(header, verifier)
 	printHeader(header, headerValid)
 
-	// Process entries
 	prevSig := header.Signature
-	openChannels := make(map[string]map[string]any) // sig -> metadata
-	var totalEntries, opens, checkpoints, closes int
-	var sigErrors int
+	channels := make(map[string]*channel) // open_sig -> channel
+	var ordered []*channel
+	var totalEntries, sigErrors int
 
 	for scanner.Scan() {
 		var entry LedgerEntry
@@ -107,27 +116,52 @@ func main() { //nolint:gocyclo
 
 		switch entry.EntryType {
 		case "open":
-			opens++
-			openChannels[entry.Signature] = entry.Metadata
+			ch := &channel{open: entry, valid: valid}
+			channels[entry.Signature] = ch
+			ordered = append(ordered, ch)
 		case "checkpoint":
-			checkpoints++
+			if ch, ok := channels[entry.OpenSignature]; ok {
+				ch.checkpoints = append(ch.checkpoints, entry)
+				ch.valid = ch.valid && valid
+			}
 		case "close":
-			closes++
-			delete(openChannels, entry.OpenSignature)
+			if ch, ok := channels[entry.OpenSignature]; ok {
+				ch.close = &entry
+				ch.valid = ch.valid && valid
+			}
 		}
 
-		printEntry(entry, valid)
+		if verbosity >= 1 {
+			printEntryTree(entry, valid)
+		}
+
 		prevSig = entry.Signature
 	}
 
+	// Compact output (default)
+	if verbosity == 0 {
+		for _, ch := range ordered {
+			printCompact(ch)
+		}
+	}
+
 	// Summary
+	opens := len(ordered)
+	var unclosed int
+	for _, ch := range ordered {
+		if ch.close == nil {
+			unclosed++
+		}
+	}
+
 	fmt.Println()
 	fmt.Println(strings.Repeat("═", 80))
-	fmt.Printf("  SUMMARY: %d entries (%d open, %d checkpoint, %d close)\n",
-		totalEntries, opens, checkpoints, closes)
+	fmt.Printf("  SUMMARY: %d entries (%d requests)\n",
+		totalEntries, opens)
 	if verifier != nil {
 		if sigErrors == 0 {
-			fmt.Printf("  SIGNATURES: ✅ All %d signatures valid\n", totalEntries+1)
+			fmt.Printf("  SIGNATURES: ✅ All %d signatures valid\n",
+				totalEntries+1)
 		} else {
 			fmt.Printf("  SIGNATURES: ❌ %d/%d failed verification\n",
 				sigErrors, totalEntries)
@@ -135,11 +169,8 @@ func main() { //nolint:gocyclo
 	} else {
 		fmt.Printf("  SIGNATURES: ⚠️  Could not verify (no public key)\n")
 	}
-	if len(openChannels) > 0 {
-		fmt.Printf("  UNCLOSED CHANNELS: %d\n", len(openChannels))
-		for sig, meta := range openChannels {
-			fmt.Printf("    • %s... %v\n", sig[:16], metaSummary(meta))
-		}
+	if unclosed > 0 {
+		fmt.Printf("  COMPLETENESS: ❌ %d unclosed channels\n", unclosed)
 	} else {
 		fmt.Printf("  COMPLETENESS: ✅ All channels closed\n")
 	}
@@ -149,15 +180,44 @@ func main() { //nolint:gocyclo
 func printHeader(h HeaderEntry, valid bool) {
 	check := sigStatus(valid)
 	fmt.Println(strings.Repeat("═", 80))
-	fmt.Printf("  LEDGER v%s  format=%s  hashes=%v\n", h.Version, h.Format, h.Hashes)
-	fmt.Printf("  environment: %v\n", h.Environment)
-	fmt.Printf("  cert: %d bytes  %s\n", h.Payload.Size, check)
+	fmt.Printf("  LEDGER v%s  format=%s  hashes=%v  %s\n",
+		h.Version, h.Format, h.Hashes, check)
+	if verbosity >= 1 {
+		fmt.Printf("  environment: %v\n", h.Environment)
+	}
 	fmt.Println(strings.Repeat("═", 80))
 }
 
-func printEntry(e LedgerEntry, valid bool) {
-	check := sigStatus(valid)
+func printCompact(ch *channel) {
+	check := sigStatus(ch.valid)
+	meta := metaSummary(ch.open.Metadata)
 
+	status := ""
+	var size int64
+	if ch.close != nil {
+		if s, ok := ch.close.Metadata["status"]; ok {
+			status = fmt.Sprintf(" %v", s)
+		}
+		size = payloadSize(ch.close.Payload)
+	} else {
+		status = " UNCLOSED"
+	}
+
+	// For artifact POSTs, show the uploaded body size (checkpoint out)
+	// rather than the empty close payload.
+	if ch.open.Metadata["schema"] == "artifact" {
+		for _, cp := range ch.checkpoints {
+			if cp.Direction == "out" && payloadSize(cp.Payload) > 0 {
+				size = payloadSize(cp.Payload)
+			}
+		}
+	}
+
+	fmt.Printf("%s%s %s (%d bytes)\n", check, status, meta, size)
+}
+
+func printEntryTree(e LedgerEntry, valid bool) {
+	check := sigStatus(valid)
 	switch e.EntryType {
 	case "open":
 		fmt.Printf("[%3d] %s OPEN %s  %s\n",
@@ -165,11 +225,13 @@ func printEntry(e LedgerEntry, valid bool) {
 	case "checkpoint":
 		dir := dirArrow(e.Direction)
 		fmt.Printf("[%3d] %s  ├─ CHECKPOINT %s %s (%d bytes)\n",
-			e.Seq, check, dir, e.Direction, payloadSize(e.Payload))
+			e.Seq, check, dir, e.Direction,
+			payloadSize(e.Payload))
 	case "close":
 		dir := dirArrow(e.Direction)
 		fmt.Printf("[%3d] %s  └─ CLOSE %s %s (%d bytes)\n",
-			e.Seq, check, dir, e.Direction, payloadSize(e.Payload))
+			e.Seq, check, dir, e.Direction,
+			payloadSize(e.Payload))
 	}
 }
 
@@ -211,7 +273,6 @@ func sigStatus(valid bool) string {
 	return "❌"
 }
 
-// sigVerifier abstracts signature verification for different schemes.
 type sigVerifier interface {
 	verify(input []byte, sigB64 string) bool
 }
@@ -239,14 +300,15 @@ func (v *rsaVerifier) verify(input []byte, sigB64 string) bool {
 		return false
 	}
 	digest := sha512.Sum512(input)
-	return rsa.VerifyPKCS1v15(v.key, crypto.SHA512, digest[:], sigBytes) == nil
+	err = rsa.VerifyPKCS1v15(v.key, crypto.SHA512, digest[:], sigBytes)
+	return err == nil
 }
 
 func reconstructVerifier(h HeaderEntry) sigVerifier {
-	if len(os.Args) < 2 {
+	if flag.NArg() < 1 {
 		return nil
 	}
-	path := strings.TrimSuffix(os.Args[1], "ledger") + "ledger.cert.pem"
+	path := strings.TrimSuffix(flag.Arg(0), "ledger") + "ledger.cert.pem"
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -257,12 +319,12 @@ func reconstructVerifier(h HeaderEntry) sigVerifier {
 	}
 
 	switch {
-	case h.SignatureScheme == "ed25519-sha512" || block.Type == "ED25519 PUBLIC KEY":
+	case h.SignatureScheme == "ed25519-sha512" ||
+		block.Type == "ED25519 PUBLIC KEY":
 		if len(block.Bytes) == ed25519.PublicKeySize {
 			return &ed25519Verifier{key: ed25519.PublicKey(block.Bytes)}
 		}
 	default:
-		// Legacy RSA
 		key, err := x509.ParsePKCS1PublicKey(block.Bytes)
 		if err == nil {
 			return &rsaVerifier{key: key}
@@ -279,7 +341,9 @@ func verifyHeader(h HeaderEntry, v sigVerifier) bool {
 	return v.verify(sigInput, h.Signature)
 }
 
-func verifyEntry(e LedgerEntry, prevSig string, hashes []string, v sigVerifier) bool {
+func verifyEntry(
+	e LedgerEntry, prevSig string, hashes []string, v sigVerifier,
+) bool {
 	var sigInput []byte
 	prevSigBytes, _ := base64.StdEncoding.DecodeString(prevSig)
 	sigInput = append(sigInput, prevSigBytes...)
@@ -294,7 +358,8 @@ func verifyEntry(e LedgerEntry, prevSig string, hashes []string, v sigVerifier) 
 		sigInput = append(sigInput, []byte(e.Direction)...)
 		if e.Payload != nil {
 			sigInput = append(sigInput, sizeBytes(e.Payload.Size)...)
-			sigInput = append(sigInput, rawHashBytes(e.Payload.Hashes, hashes)...)
+			sigInput = append(sigInput,
+				rawHashBytes(e.Payload.Hashes, hashes)...)
 		}
 	}
 

--- a/cmd/ledger-inspect/main.go
+++ b/cmd/ledger-inspect/main.go
@@ -16,6 +16,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"warden/relay"
+
+	"github.com/fxamacker/cbor/v2"
 )
 
 type HeaderEntry struct {
@@ -53,6 +57,13 @@ type channel struct {
 	valid       bool // all entries in this channel verified
 }
 
+// v3channel tracks a complete request lifecycle for v3 binary ledgers.
+type v3channel struct {
+	open        relay.Ledger3Record
+	checkpoints []relay.Ledger3Record
+	close       *relay.Ledger3Record
+}
+
 var verbosity int
 
 func main() { //nolint:gocyclo
@@ -75,6 +86,20 @@ func main() { //nolint:gocyclo
 	}
 	defer f.Close()
 
+	// Read file to detect format
+	data, err := os.ReadFile(flag.Arg(0))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Detect v3 binary format by magic bytes
+	if relay.IsLedger3(data) {
+		inspectV3(data)
+		return
+	}
+
+	// Fall through to v2 JSON format
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 4*1024*1024), 4*1024*1024)
 
@@ -379,4 +404,139 @@ func rawHashBytes(hashes map[string]string, order []string) []byte {
 		out = append(out, b...)
 	}
 	return out
+}
+
+func inspectV3(data []byte) {
+	result, err := relay.VerifyLedger3(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	h := result.Header
+	headerValid := result.SigErrors == 0 || verifyV3Header(h)
+
+	// Print header
+	fmt.Println(strings.Repeat("═", 80))
+	fmt.Printf("  LEDGER v3 (binary)  scheme=%s  hashes=%v  %s\n",
+		h.SigScheme, h.Meta.Hashes, sigStatus(headerValid))
+	if verbosity >= 1 {
+		fmt.Printf("  sig_size=%d  hash_block_size=%d  pub_key_len=%d\n",
+			h.SigSize, h.HashBlockSize, h.PubKeyLen)
+		fmt.Printf("  schemas=%v\n", h.Meta.Schemas)
+		fmt.Printf("  environment: %v\n", h.Meta.Environment)
+	}
+	fmt.Println(strings.Repeat("═", 80))
+
+	// Track channels for compact output
+	channels := make(map[string]*v3channel)
+	var ordered []*v3channel
+
+	for i, rec := range result.Records {
+		if verbosity >= 1 {
+			printV3EntryTree(i, rec, h)
+		}
+
+		sigKey := string(rec.Signature)
+		switch rec.Type {
+		case relay.RecordOpen:
+			ch := &v3channel{open: rec}
+			channels[sigKey] = ch
+			ordered = append(ordered, ch)
+		case relay.RecordCheckpoint:
+			if ch, ok := channels[string(rec.OpenSig)]; ok {
+				ch.checkpoints = append(ch.checkpoints, rec)
+			}
+		case relay.RecordClose, relay.RecordArtifact:
+			if ch, ok := channels[string(rec.OpenSig)]; ok {
+				ch.close = &rec
+			}
+		}
+	}
+
+	// Compact output
+	if verbosity == 0 {
+		for _, ch := range ordered {
+			printV3Compact(ch, h)
+		}
+	}
+
+	// Summary
+	fmt.Println()
+	fmt.Println(strings.Repeat("═", 80))
+	fmt.Printf("  SUMMARY: %d entries (%d requests)\n",
+		result.TotalRecords, len(ordered))
+	if result.SigErrors == 0 {
+		fmt.Printf("  SIGNATURES: ✅ All %d signatures valid\n",
+			result.TotalRecords+1) // +1 for header
+	} else {
+		fmt.Printf("  SIGNATURES: ❌ %d signature error(s)\n", result.SigErrors)
+	}
+	if result.Unclosed > 0 {
+		fmt.Printf("  COMPLETENESS: ❌ %d unclosed channels\n", result.Unclosed)
+	} else {
+		fmt.Printf("  COMPLETENESS: ✅ All channels closed\n")
+	}
+	fmt.Println(strings.Repeat("═", 80))
+}
+
+func verifyV3Header(h relay.Ledger3Header) bool {
+	digest := sha512.Sum512(h.PrefixBytes)
+	return ed25519.Verify(h.PubKey, digest[:], h.Signature)
+}
+
+func printV3EntryTree(seq int, r relay.Ledger3Record, h relay.Ledger3Header) {
+	check := "✅"
+	switch r.Type {
+	case relay.RecordOpen:
+		meta := v3MetaSummary(r, h)
+		fmt.Printf("[%3d] %s OPEN %s\n", seq+1, check, meta)
+	case relay.RecordCheckpoint:
+		dir := dirArrow(r.Direction())
+		fmt.Printf("[%3d] %s  ├─ CHECKPOINT %s %s (%d bytes)\n",
+			seq+1, check, dir, r.Direction(), r.AbsPayloadSize())
+	case relay.RecordClose:
+		dir := dirArrow(r.Direction())
+		fmt.Printf("[%3d] %s  └─ CLOSE %s %s (%d bytes)\n",
+			seq+1, check, dir, r.Direction(), r.AbsPayloadSize())
+	case relay.RecordArtifact:
+		meta := v3MetaSummary(r, h)
+		fmt.Printf("[%3d] %s  └─ ARTIFACT %s (%d bytes)\n",
+			seq+1, check, meta, r.AbsPayloadSize())
+	}
+}
+
+func printV3Compact(ch *v3channel, h relay.Ledger3Header) {
+	meta := v3MetaSummary(ch.open, h)
+	status := ""
+	var size int64
+	if ch.close != nil {
+		size = ch.close.AbsPayloadSize()
+		if ch.close.Type == relay.RecordArtifact {
+			status = " ARTIFACT"
+		}
+	} else {
+		status = " UNCLOSED"
+	}
+	fmt.Printf("✅%s %s (%d bytes)\n", status, meta, size)
+}
+
+func v3MetaSummary(r relay.Ledger3Record, h relay.Ledger3Header) string {
+	if r.Metadata == nil {
+		return ""
+	}
+	var m map[string]any
+	if err := cbor.Unmarshal(r.Metadata, &m); err != nil {
+		return ""
+	}
+	method, _ := m["method"].(string)
+	url, _ := m["url"].(string)
+	name, _ := m["name"].(string)
+	if method != "" && url != "" {
+		return fmt.Sprintf("%s %s", method, url)
+	}
+	if name != "" {
+		return fmt.Sprintf("→ %s", name)
+	}
+	return ""
 }

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/pem"
 	"fmt"
 	"net"
 	"os"
@@ -31,14 +32,15 @@ func run() int {
 	}
 	defer ledgerFile.Close()
 
-	err = relay.NewLedger(ledgerFile, map[string]any{
-		"type": "container",
+	l, err := relay.NewLedger3(relay.Ledger3Config{
+		Writer:      ledgerFile,
+		Environment: map[string]any{"type": "container"},
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error initializing ledger: %v\n", err)
 		return 1
 	}
-
+	relay.SetLedger3(l)
 	relay.SetOutDir(outDir)
 
 	// Generate ephemeral CA for this build.
@@ -54,8 +56,11 @@ func run() int {
 		return 1
 	}
 
-	// Write public cert files.
-	certPEM := relay.PublicCertPEM()
+	// Write ledger public key in PEM format.
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "ED25519 PUBLIC KEY",
+		Bytes: []byte(l.PublicKey()),
+	})
 	certPath := filepath.Join(outDir, "ledger.cert.pem")
 	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "error writing cert PEM: %v\n", err)
@@ -74,7 +79,7 @@ func run() int {
 	// Block until any listener fails.
 	if err := <-errs; err != nil {
 		fmt.Fprintf(os.Stderr, "relay error: %v\n", err)
-		relay.FinishLedger()
+		l.Finish()
 		return 1
 	}
 

--- a/docs/design/Ledger-Spec-v3.md
+++ b/docs/design/Ledger-Spec-v3.md
@@ -1,0 +1,537 @@
+# BuildWarden Ledger Specification v3 — Binary Format
+
+## Purpose
+
+A build ledger is a document providing a completeness guarantee for inputs and outputs during a build process as strictly-ordered entries with a chaining signature. It is produced by the BuildWarden relay — an ephemeral TLS-terminating proxy that observes all network traffic during an isolated build.
+
+The ledger is designed to be:
+
+- **Verifiable**: Any holder of the ledger can validate the signature chain using only the public key embedded in the header. Verification requires no knowledge of hash algorithm names or metadata schemas — only the declared sizes.
+- **Tamper-evident**: Altering, reordering, inserting, or removing any entry invalidates all subsequent signatures.
+- **Redactable**: Metadata is CBOR-encoded, not part of signatures, and can be stripped or modified without affecting ledger integrity.
+- **Complete**: Every network resource consumed or produced during the build is recorded with content-addressable identity (size + ordered hash block).
+- **Deterministic**: All signed content has a fixed byte layout derivable from header parameters. No parsing ambiguity exists in the signed portion of any record.
+
+## Conventions
+
+- All multi-byte integers are **big-endian** (network byte order).
+- Strings in the binary prefix of the header are **null-terminated UTF-8**.
+- CBOR objects follow [RFC 8949](https://www.rfc-editor.org/rfc/rfc8949.html).
+- Signature inputs are the raw concatenation of the specified fields — no additional framing or separators.
+
+## File Layout
+
+```
+<ledger_root>/
+├── ledger                  # The binary ledger file
+├── ledger.cert.pem         # Public certificate in PEM format (convenience copy)
+├── payloads/
+│   └── <hex_hash>          # Payload files stored by primary hash
+├── artifacts/
+│   └── <name>              # Artifact files (or symlinks to payloads/)
+└── metadata/
+    └── <stream>            # Optional append-only metadata streams
+```
+
+## Ledger File Structure
+
+The ledger file is a concatenation of:
+
+```
+[Header] [Record 0] [Record 1] ... [Record N]
+```
+
+There are no delimiters between records. Record boundaries are determined by the record structure and sizes declared in the header.
+
+---
+
+## Header
+
+The header establishes the cryptographic parameters, embeds the public key, and provides informational metadata.
+
+### Binary Prefix
+
+| Offset | Size | Field | Description |
+|--------|------|-------|-------------|
+| 0 | 4 | Magic | ASCII `BLDL` (0x42 0x4C 0x44 0x4C) |
+| 4 | 1 | Version | Ledger spec version (0x03 for this spec) |
+| 5 | variable | Signature scheme | Null-terminated UTF-8 string (e.g., `ed25519-sha512\0`) |
+| — | 2 | Signature size | uint16 — byte length of all signatures in this ledger |
+| — | 2 | Hash block size | uint16 — total byte length of concatenated hashes per payload |
+| — | 2 | Public key length | uint16 — byte length of the public key |
+| — | variable | Public key bytes | Raw public key (length per above field) |
+
+The binary prefix ends immediately after the public key bytes. Its total size is:
+
+```
+5 + len(signature_scheme) + 1 + 2 + 2 + 2 + public_key_length
+```
+
+### Header Signature
+
+Immediately following the binary prefix:
+
+| Size | Field | Description |
+|------|-------|-------------|
+| signature-size | Header signature | Signs all bytes of the binary prefix |
+
+**Signature input**: All bytes from offset 0 through the end of the public key bytes (the entire binary prefix).
+
+The header signature serves as the **chain root** — it becomes the `prev_sig` for the first record.
+
+### Header Metadata (CBOR)
+
+Following the header signature:
+
+| Size | Field | Description |
+|------|-------|-------------|
+| 4 | Metadata length | uint32 — byte length of the CBOR object that follows |
+| variable | CBOR object | Informational header metadata |
+
+The header metadata is a CBOR map containing:
+
+```cbor
+{
+  "hashes": ["blake2b_256", "sha256", "sha1", "md5"],
+  "schemas": [
+    "https://github.com/buildwarden/buildwarden/schemas/http-open.json",
+    "https://github.com/buildwarden/buildwarden/schemas/http-headers.json",
+    "https://github.com/buildwarden/buildwarden/schemas/http-body.json",
+    "https://github.com/buildwarden/buildwarden/schemas/artifact.json",
+    "https://github.com/buildwarden/buildwarden/schemas/redacted.json"
+  ],
+  "environment": {
+    "type": "container",
+    "digest": "<container_digest>"
+  }
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `hashes` | array of text | Ordered list of hash algorithm names. The concatenation of their outputs equals `hash_block_size` bytes. |
+| `schemas` | array of text | Ordered list of JSON Schema URLs. Index position maps to the schema index byte in records. |
+| `environment` | map | Informational build environment description. |
+
+The header metadata is **not signed** and may be modified without invalidating the ledger. It is informational context for consumers.
+
+**Note**: The `schemas` list may be updated after ledger creation (e.g., appending new schemas) without invalidating the signature chain, since header metadata is not signed. Existing schema indices remain stable.
+
+---
+
+## Record Types
+
+| Byte Value | Name | Description |
+|------------|------|-------------|
+| 0x01 | `open` | Opens a new channel |
+| 0x02 | `checkpoint` | Intermediate data on an open channel |
+| 0x03 | `close` | Closes a channel |
+| 0x04 | `artifact` | Closes a channel, marking the payload as a build artifact |
+
+---
+
+## Record Layout
+
+### Open Record
+
+```
+[Record type: 1 byte]           — 0x01
+[Previous signature]            — signature-size bytes
+[Payload size: 8 bytes]         — int64, big-endian (typically 0)
+[Hash block]                    — hash-block-size bytes (OMITTED if payload size = 0)
+[Record signature]              — signature-size bytes
+[Schema index: 1 byte]          — 0-254 = index, 255 = no metadata
+[Metadata length: 4 bytes]      — uint32 (OMITTED if schema index = 255)
+[CBOR metadata]                 — (OMITTED if schema index = 255)
+```
+
+Open records do **not** include an open-signature field.
+
+**Signature input**:
+```
+record_type(0x01) + prev_sig + payload_size
+```
+
+When payload size = 0 (the common case), the signature input is:
+```
+0x01 + prev_sig + 0x0000000000000000
+```
+
+When payload size ≠ 0, the hash block is appended to the signature input:
+```
+0x01 + prev_sig + payload_size_bytes + hash_block
+```
+
+### Checkpoint Record
+
+```
+[Record type: 1 byte]           — 0x02
+[Previous signature]            — signature-size bytes
+[Open signature]                — signature-size bytes
+[Payload size: 8 bytes]         — int64, big-endian (sign = direction)
+[Hash block]                    — hash-block-size bytes (OMITTED if payload size = 0)
+[Record signature]              — signature-size bytes
+[Schema index: 1 byte]          — 0-254 = index, 255 = no metadata
+[Metadata length: 4 bytes]      — uint32 (OMITTED if schema index = 255)
+[CBOR metadata]                 — (OMITTED if schema index = 255)
+```
+
+**Signature input**:
+```
+record_type(0x02) + prev_sig + open_sig + payload_size_bytes + hash_block
+```
+
+When payload size = 0:
+```
+0x02 + prev_sig + open_sig + 0x0000000000000000
+```
+
+### Close Record
+
+```
+[Record type: 1 byte]           — 0x03
+[Previous signature]            — signature-size bytes
+[Open signature]                — signature-size bytes
+[Payload size: 8 bytes]         — int64, big-endian (sign = direction)
+[Hash block]                    — hash-block-size bytes (OMITTED if payload size = 0)
+[Record signature]              — signature-size bytes
+[Schema index: 1 byte]          — 0-254 = index, 255 = no metadata
+[Metadata length: 4 bytes]      — uint32 (OMITTED if schema index = 255)
+[CBOR metadata]                 — (OMITTED if schema index = 255)
+```
+
+**Signature input**: Identical structure to checkpoint.
+```
+record_type(0x03) + prev_sig + open_sig + payload_size_bytes + hash_block
+```
+
+### Artifact Record
+
+```
+[Record type: 1 byte]           — 0x04
+[Previous signature]            — signature-size bytes
+[Open signature]                — signature-size bytes
+[Payload size: 8 bytes]         — int64, big-endian
+[Hash block]                    — hash-block-size bytes (OMITTED if payload size = 0)
+[Record signature]              — signature-size bytes
+[Schema index: 1 byte]          — 0-254 = index, 255 = no metadata
+[Metadata length: 4 bytes]      — uint32 (OMITTED if schema index = 255)
+[CBOR metadata]                 — (OMITTED if schema index = 255)
+```
+
+**Signature input**: Identical structure to close.
+```
+record_type(0x04) + prev_sig + open_sig + payload_size_bytes + hash_block
+```
+
+The artifact record closes its channel (same semantics as `close`). Its record type structurally identifies the payload as a build output.
+
+**Constraints**:
+- Payload size of 0 is valid (empty artifact).
+- When payload size is non-zero, it SHOULD be negative (indicating `out` direction), though validators MUST NOT reject based on sign alone — the record type is authoritative.
+
+---
+
+## Payload Size and Direction
+
+The payload size field is a **signed 64-bit big-endian integer**.
+
+| Value | Meaning |
+|-------|---------|
+| > 0 (positive) | Data flowing **into** the build (response bodies, downloaded resources) |
+| < 0 (negative) | Data flowing **out of** the build (request bodies, artifact submissions) |
+| = 0 | No payload / directionless |
+
+The absolute value of the payload size is the byte length of the payload content. When non-zero, the hash block immediately follows the payload size field.
+
+When payload size = 0, the hash block is **omitted entirely** — no bytes are present for it. This applies uniformly to all record types.
+
+---
+
+## Hash Block
+
+The hash block is the raw concatenation of hash digests in the order declared by the header's `hashes` array. Its total size equals the header's `hash_block_size` field.
+
+Example with default hashes `["blake2b_256", "sha256", "sha1", "md5"]`:
+
+| Hash | Output Size |
+|------|-------------|
+| blake2b_256 | 32 bytes |
+| sha256 | 32 bytes |
+| sha1 | 20 bytes |
+| md5 | 16 bytes |
+| **Total** | **100 bytes** |
+
+The hash block size declared in the header would be 100 (0x0064).
+
+Payload content is written to `payloads/<primary_hash_hex>` where the primary hash is the first algorithm in the header's hash list.
+
+---
+
+## Signature Computation
+
+### Signature Schemes
+
+The signature scheme is declared as a null-terminated string in the header. The scheme name encodes both the signing algorithm and the digest algorithm.
+
+| Scheme | Signing Algorithm | Digest | Key Size | Signature Size |
+|--------|-------------------|--------|----------|----------------|
+| `ed25519-sha512` | Ed25519 | SHA-512 | 32 bytes | 64 bytes |
+| `rsa-pkcs1v15-sha512` | RSA PKCS#1 v1.5 | SHA-512 | variable | variable |
+
+For all schemes:
+1. Concatenate the signature input bytes as specified per record type.
+2. Compute the digest (SHA-512) of the concatenated input.
+3. Sign the digest with the private key using the declared algorithm.
+
+### Chain Integrity
+
+Each record's signature incorporates the previous record's signature (`prev_sig`), forming a hash chain:
+
+```
+Header sig ← Record 0 sig ← Record 1 sig ← ... ← Record N sig
+```
+
+Altering, removing, or reordering any record breaks the chain for all subsequent records.
+
+---
+
+## Metadata
+
+### Schema Index
+
+Each record carries a 1-byte schema index:
+
+| Value | Meaning |
+|-------|---------|
+| 0–254 | Index into the header's `schemas` array |
+| 255 | No metadata attached |
+
+When schema index = 255, no metadata length or CBOR bytes follow. When schema index is 0–254, a 4-byte uint32 length followed by that many bytes of CBOR-encoded metadata immediately follow.
+
+Metadata is **never** part of the signature input. It can be freely added, modified, or stripped without affecting ledger validity.
+
+### One Schema Per Record
+
+Each record has at most one metadata attachment. The schema index identifies which schema the CBOR object conforms to.
+
+---
+
+## Default Schemas
+
+BuildWarden defines the following default schemas. Their indices are determined by position in the header's `schemas` array (not fixed by this spec).
+
+### `http-open`
+
+Attached to `open` records for HTTP/HTTPS channels.
+
+```cbor
+{
+  "method": "GET",
+  "url": "https://example.com/path",
+  "protocol": "HTTP/1.1"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | text | HTTP method |
+| `url` | text | Full request URL |
+| `protocol` | text | Protocol version |
+
+### `http-headers`
+
+Attached to `checkpoint` records carrying HTTP headers as payload.
+
+```cbor
+{
+  "headers": [
+    ["X-Amz-Request-Id", "abc123"],
+    ["X-Custom-Header", "value"],
+    ["Authorization", "<redacted>"],
+    ["Cookie", "<redacted>"],
+    ["Set-Cookie", "<redacted>"]
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `headers` | array of [name, value] | Non-standard headers. Auth-related headers (`Authorization`, `Cookie`, `Set-Cookie`, `Proxy-Authorization`) are listed with value `<redacted>`. Standard/structural HTTP headers (those defined in HTTP/1.1 and HTTP/2 base specifications) are omitted — they exist in the raw payload bytes. |
+
+### `http-body`
+
+Attached to `checkpoint` or `close` records carrying HTTP body content as payload.
+
+```cbor
+{
+  "status": 200
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | unsigned int | HTTP response status code (present only for response bodies) |
+
+### `artifact`
+
+Attached to `artifact` records.
+
+```cbor
+{
+  "name": "my-binary",
+  "context": {
+    "content_type": "application/octet-stream"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | text | Filename as stored in the ledger's `artifacts/` directory |
+| `context` | map | Freeform key-value map for additional artifact metadata |
+
+### `redacted`
+
+Attached to any record whose original metadata has been stripped or was never recorded.
+
+```cbor
+{
+  "owner": "corp.amazon.com"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `owner` | text | Identifier of the party responsible for or owning the redacted information |
+
+---
+
+## HTTP Protocol Mapping
+
+For HTTP/HTTPS requests proxied by the relay, the typical entry sequence is:
+
+### GET Request (resource consumed by build)
+
+| # | Type | Payload Dir | Payload Content | Schema |
+|---|------|-------------|-----------------|--------|
+| 1 | open | — (0) | — | `http-open` |
+| 2 | checkpoint | out (−) | Request headers (raw bytes) | `http-headers` |
+| 3 | checkpoint | in (+) | Response headers (raw bytes) | `http-headers` |
+| 4 | close | in (+) | Response body | `http-body` |
+
+### POST Request (data sent from build)
+
+| # | Type | Payload Dir | Payload Content | Schema |
+|---|------|-------------|-----------------|--------|
+| 1 | open | — (0) | — | `http-open` |
+| 2 | checkpoint | out (−) | Request headers (raw bytes) | `http-headers` |
+| 3 | checkpoint | out (−) | Request body | `http-body` |
+| 4 | checkpoint | in (+) | Response headers (raw bytes) | `http-headers` |
+| 5 | close | in (+) | Response body | `http-body` |
+
+### Artifact Submission
+
+| # | Type | Payload Dir | Payload Content | Schema |
+|---|------|-------------|-----------------|--------|
+| 1 | open | — (0) | — | `http-open` |
+| 2 | checkpoint | out (−) | Request headers (raw bytes) | `http-headers` |
+| 3 | artifact | out (−) | Artifact body | `artifact` |
+
+---
+
+## Redactability
+
+Metadata is excluded from all signatures. This allows:
+
+- Stripping URLs, hostnames, and internal identifiers from `http-open` metadata.
+- Replacing any record's metadata with the `redacted` schema (changing the schema index byte and CBOR content).
+- Removing metadata entirely (setting schema index to 255 and removing the length + CBOR bytes).
+
+After redaction, the signature chain remains fully valid. The content identity (payload size + hash block) is preserved, proving *what* was transferred without revealing *where* it came from.
+
+The `redacted` schema provides attribution — identifying who owns or is responsible for the redacted information — enabling downstream consumers to request the full metadata from the appropriate party if needed.
+
+---
+
+## Completeness
+
+A channel is **complete** when its open entry has a corresponding close or artifact entry.
+
+A ledger is **complete** when all opened channels are closed.
+
+A **payload's provenance** is complete when:
+1. The channel containing the payload is closed.
+2. All channels opened before that close are themselves closed.
+
+---
+
+## Verification Algorithm
+
+A minimal verifier needs only:
+- The binary prefix fields (signature scheme, signature size, hash block size, public key)
+- The ability to compute the declared digest (SHA-512) and verify the declared signature scheme
+
+```
+1. Read binary prefix, extract: sig_scheme, sig_size, hash_block_size, public_key
+2. Verify header signature over the binary prefix bytes
+3. Set prev_sig = header_signature
+4. Skip header metadata (read 4-byte length, skip that many bytes)
+5. For each record:
+   a. Read record_type (1 byte)
+   b. Read prev_sig_field (sig_size bytes) — must equal prev_sig
+   c. If record_type != 0x01: read open_sig (sig_size bytes)
+   d. Read payload_size (8 bytes, signed int64)
+   e. If payload_size != 0: read hash_block (hash_block_size bytes)
+   f. Reconstruct signature input from fields read in (a–e)
+   g. Read record_signature (sig_size bytes)
+   h. Verify record_signature against signature input using public_key
+   i. Set prev_sig = record_signature
+   j. Read schema_index (1 byte)
+   k. If schema_index != 255: read metadata_length (4 bytes), skip that many bytes
+6. If all signatures verify: ledger is valid
+```
+
+Note: The verifier does not need a CBOR parser, knowledge of hash algorithm names, or awareness of metadata schemas. It operates entirely on the deterministic byte layout.
+
+---
+
+## Error Handling
+
+If a network request fails (timeout, connection reset, server error):
+- The relay still emits a close entry for the channel.
+- The close entry's payload size may be 0 (nothing received).
+- Metadata may indicate the error condition.
+- No open channel is left dangling in a well-formed ledger.
+
+---
+
+## Future Considerations
+
+- **File-system tracing**: Additional record types for local file I/O via syscall tracing.
+- **Payload recording configuration**: Configurable rules for which payloads are stored to disk vs. only hashed.
+- **Auto-redaction**: Configuration-driven redaction of metadata for specific hostnames at ledger-creation time.
+- **Additional signature schemes**: The null-terminated scheme string and explicit size fields allow new schemes without format changes.
+- **Compression**: CBOR metadata could be compressed; the length-prefix framing supports this transparently.
+
+---
+
+## Appendix: Worked Example
+
+Given: `ed25519-sha512` scheme, default hash set `[blake2b_256, sha256, sha1, md5]`.
+
+Header parameters:
+- Signature size: 64 bytes
+- Hash block size: 100 bytes (32 + 32 + 20 + 16)
+- Public key length: 32 bytes
+
+### Record sizes (excluding metadata)
+
+| Record Type | Fixed Size |
+|-------------|-----------|
+| Open (payload=0) | 1 + 64 + 8 + 64 + 1 = **138 bytes** |
+| Open (payload≠0) | 1 + 64 + 8 + 100 + 64 + 1 = **238 bytes** |
+| Checkpoint/Close/Artifact (payload=0) | 1 + 64 + 64 + 8 + 64 + 1 = **202 bytes** |
+| Checkpoint/Close/Artifact (payload≠0) | 1 + 64 + 64 + 8 + 100 + 64 + 1 = **302 bytes** |
+
+Metadata adds: 4 bytes (length) + CBOR content length.

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,9 @@ require (
 )
 
 require (
+	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
+github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -14,6 +16,8 @@ github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=

--- a/pkg/container.go
+++ b/pkg/container.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/lesiw/ctrctl"
 )
@@ -22,10 +23,10 @@ var exts = []Extension{
 }
 
 const (
-	relayIP   = "10.0.87.2"
-	buildIP   = "10.0.87.3"
-	subnet    = "10.0.87.0/29"
-	gateway   = "10.0.87.1"
+	relayIP          = "10.0.87.2"
+	buildIP          = "10.0.87.3"
+	subnet           = "10.0.87.0/29"
+	rootlessDockerSock = "unix:///run/user/1000/docker.sock"
 )
 
 type CtrEnv struct {
@@ -72,6 +73,8 @@ func (d *CtrEnv) Build(config *BuildConfig) error {
 					Stderr: os.Stderr,
 				},
 				Interactive: true,
+				User:        "rootless",
+				Env:         "DOCKER_HOST=" + rootlessDockerSock,
 			},
 			d.buildContainer,
 			"docker", "build", "--network=host", "-f", config.Containerfile, ".",
@@ -105,12 +108,6 @@ func (d *CtrEnv) createBuildEnv() error {
 		return fmt.Errorf("error creating %s: %w", d.wardenDirPath(), err)
 	}
 
-	for _, ext := range exts {
-		if err := ext.BeforeBuild(d); err != nil {
-			return err
-		}
-	}
-
 	d.buildId = randanum(8)
 
 	// Create a host directory for ledger output.
@@ -125,10 +122,18 @@ func (d *CtrEnv) createBuildEnv() error {
 	if err := d.createNetwork(); err != nil {
 		return err
 	}
-	if err := d.editContainerfile(); err != nil {
+	if err := d.startRelayContainer(); err != nil {
 		return err
 	}
-	if err := d.startRelayContainer(); err != nil {
+
+	// Extensions run after the relay is up — they need its CA cert.
+	for _, ext := range exts {
+		if err := ext.BeforeBuild(d); err != nil {
+			return err
+		}
+	}
+
+	if err := d.editContainerfile(); err != nil {
 		return err
 	}
 	if err := d.startBuildContainer(); err != nil {
@@ -196,14 +201,15 @@ ENTRYPOINT ["relay"]
 }
 
 func (d *CtrEnv) createNetwork() error {
-	// Network for relay and build container. Not marked internal —
-	// the relay needs external access. Build container isolation is
-	// enforced via iptables rules that only allow traffic to the relay.
+	// Isolated network for relay and build container.
+	// The relay needs external access to forward build traffic upstream.
+	// Build container isolation is enforced by:
+	//   1. iptables OUTPUT rules (only relay + loopback allowed)
+	//   2. Deleting the default route (no path to gateway even if iptables flushed)
 	id, err := ctrctl.NetworkCreate(
 		&ctrctl.NetworkCreateOpts{
-			Driver:  "bridge",
-			Gateway: gateway,
-			Subnet:  subnet,
+			Driver: "bridge",
+			Subnet: subnet,
 		},
 		"warden-"+d.buildId,
 	)
@@ -234,17 +240,21 @@ func (d *CtrEnv) startRelayContainer() error {
 }
 
 func (d *CtrEnv) startBuildContainer() error {
+	// The container needs --privileged for rootlesskit to create user
+	// namespaces. However, the inner dockerd and all build processes run
+	// as the unprivileged "rootless" user, which cannot modify iptables
+	// or routes in the real network namespace.
 	id, err := ctrctl.ContainerRun(
 		&ctrctl.ContainerRunOpts{
 			Detach:     true,
 			Name:       "warden-build-" + d.buildId,
 			Network:    "warden-" + d.buildId,
 			Ip:         buildIP,
-			Privileged: true, // TODO: investigate nonprivileged alternatives.
+			Privileged: true,
 			Workdir:    "/work",
 		},
-		"docker:dind",
-		"sleep", "infinity",
+		"docker:dind-rootless",
+		"",
 	)
 	if err != nil {
 		return err
@@ -263,6 +273,9 @@ func (d *CtrEnv) configureBuildContainer() error {
 		return err
 	}
 
+	// Network isolation rules applied as privileged exec from the
+	// orchestrator. The rootless build container cannot override these
+	// because it lacks CAP_NET_ADMIN.
 	cmds := [][]string{
 		// Point DNS at the relay.
 		{"sh", "-c", fmt.Sprintf(`echo "nameserver %s" > /etc/resolv.conf`, relayIP)},
@@ -275,13 +288,17 @@ func (d *CtrEnv) configureBuildContainer() error {
 		{"iptables", "-A", "OUTPUT", "-d", relayIP, "-j", "ACCEPT"},
 		{"iptables", "-A", "OUTPUT", "-d", "127.0.0.0/8", "-j", "ACCEPT"},
 		{"iptables", "-A", "OUTPUT", "-j", "DROP"},
+		// Defense-in-depth: replace the default route with one pointing at
+		// the relay. Even if iptables are flushed, all traffic still goes
+		// to the relay (which won't forward unrecognized traffic).
+		{"ip", "route", "replace", "default", "via", relayIP},
 		// Set up warden extensions.
 		{"ln", "-s", "/work/.warden", "/.warden"},
 		{"find", "/.warden/ext.d/", "-exec", "sh", "{}", ";"},
 	}
 	for _, cmd := range cmds {
 		_, err := ctrctl.ContainerExec(
-			&ctrctl.ContainerExecOpts{Privileged: true},
+			&ctrctl.ContainerExecOpts{Privileged: true, User: "0"},
 			d.buildContainer,
 			cmd[0],
 			cmd[1:]...,
@@ -291,14 +308,20 @@ func (d *CtrEnv) configureBuildContainer() error {
 		}
 	}
 
-	// Start dockerd inside the build container.
-	_, err = ctrctl.ContainerExec(
-		&ctrctl.ContainerExecOpts{Detach: true},
-		d.buildContainer,
-		"dockerd",
-	)
+	// Wait for the rootless docker daemon (started by the image entrypoint).
+	for i := 0; i < 50; i++ {
+		_, err = ctrctl.ContainerExec(
+			&ctrctl.ContainerExecOpts{User: "rootless", Env: "DOCKER_HOST=" + rootlessDockerSock},
+			d.buildContainer,
+			"docker", "info",
+		)
+		if err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("timed out waiting for rootless dockerd: %w", err)
 	}
 
 	return nil

--- a/pkg/container.go
+++ b/pkg/container.go
@@ -311,7 +311,10 @@ func (d *CtrEnv) configureBuildContainer() error {
 	// Wait for the rootless docker daemon (started by the image entrypoint).
 	for i := 0; i < 50; i++ {
 		_, err = ctrctl.ContainerExec(
-			&ctrctl.ContainerExecOpts{User: "rootless", Env: "DOCKER_HOST=" + rootlessDockerSock},
+			&ctrctl.ContainerExecOpts{
+				User: "rootless",
+				Env:  "DOCKER_HOST=" + rootlessDockerSock,
+			},
 			d.buildContainer,
 			"docker", "info",
 		)

--- a/relay/ledger3.go
+++ b/relay/ledger3.go
@@ -119,7 +119,11 @@ func NewLedger3(cfg Ledger3Config) (*Ledger3, error) {
 
 // PublicKey returns the raw Ed25519 public key bytes.
 func (l *Ledger3) PublicKey() ed25519.PublicKey {
-	return l.key.Public().(ed25519.PublicKey)
+	pub, ok := l.key.Public().(ed25519.PublicKey)
+	if !ok {
+		panic("unexpected key type")
+	}
+	return pub
 }
 
 // Open writes an open record synchronously and returns the record's raw signature
@@ -139,7 +143,10 @@ func (l *Ledger3) Open(schemaIndex byte, metadata []byte) []byte {
 }
 
 // Checkpoint writes a checkpoint record (fire-and-forget).
-func (l *Ledger3) Checkpoint(openSig []byte, payloadSize int64, hashBlock []byte, schemaIndex byte, metadata []byte) {
+func (l *Ledger3) Checkpoint(
+	openSig []byte, payloadSize int64, hashBlock []byte,
+	schemaIndex byte, metadata []byte,
+) {
 	l.entries <- entry3Request{
 		entry: entry3Input{
 			Type:        RecordCheckpoint,
@@ -153,7 +160,10 @@ func (l *Ledger3) Checkpoint(openSig []byte, payloadSize int64, hashBlock []byte
 }
 
 // Close writes a close record (fire-and-forget).
-func (l *Ledger3) Close(openSig []byte, payloadSize int64, hashBlock []byte, schemaIndex byte, metadata []byte) {
+func (l *Ledger3) Close(
+	openSig []byte, payloadSize int64, hashBlock []byte,
+	schemaIndex byte, metadata []byte,
+) {
 	l.entries <- entry3Request{
 		entry: entry3Input{
 			Type:        RecordClose,
@@ -167,7 +177,10 @@ func (l *Ledger3) Close(openSig []byte, payloadSize int64, hashBlock []byte, sch
 }
 
 // Artifact writes an artifact record (fire-and-forget). Closes the channel.
-func (l *Ledger3) Artifact(openSig []byte, payloadSize int64, hashBlock []byte, schemaIndex byte, metadata []byte) {
+func (l *Ledger3) Artifact(
+	openSig []byte, payloadSize int64, hashBlock []byte,
+	schemaIndex byte, metadata []byte,
+) {
 	l.entries <- entry3Request{
 		entry: entry3Input{
 			Type:        RecordArtifact,

--- a/relay/ledger3.go
+++ b/relay/ledger3.go
@@ -1,0 +1,364 @@
+package relay
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"io"
+	"log"
+	"sync/atomic"
+
+	"github.com/fxamacker/cbor/v2"
+	"golang.org/x/crypto/blake2b"
+)
+
+// Record type byte values per Ledger Spec v3.
+const (
+	RecordOpen       byte = 0x01
+	RecordCheckpoint byte = 0x02
+	RecordClose      byte = 0x03
+	RecordArtifact   byte = 0x04
+)
+
+// SchemaNoMetadata indicates no metadata is attached to a record.
+const SchemaNoMetadata byte = 0xFF
+
+// Ledger3 implements the BuildWarden binary ledger v3 specification.
+// All writes are serialized through a single channel.
+type Ledger3 struct {
+	key           ed25519.PrivateKey
+	writer        io.Writer
+	entries       chan entry3Request
+	done          chan struct{}
+	seq           atomic.Int64
+	hashes        []string
+	sigSize       int
+	hashBlockSize int
+	prevSigRaw    []byte
+	sigBuf        []byte // reusable buffer for signature input
+}
+
+type entry3Request struct {
+	entry  entry3Input
+	result chan<- []byte // nil for fire-and-forget; returns raw signature for open
+}
+
+type entry3Input struct {
+	Type        byte
+	OpenSig     []byte // for checkpoint/close/artifact
+	PayloadSize int64  // signed: negative=out, positive=in, 0=none
+	HashBlock   []byte // raw concatenated hashes (nil when payload=0)
+	SchemaIndex byte
+	Metadata    []byte // pre-encoded CBOR (nil when SchemaIndex=0xFF)
+}
+
+// Ledger3HeaderMeta is the CBOR metadata written after the header signature.
+type Ledger3HeaderMeta struct {
+	Hashes      []string       `cbor:"hashes"`
+	Schemas     []string       `cbor:"schemas"`
+	Environment map[string]any `cbor:"environment"`
+}
+
+// Ledger3Config holds parameters for creating a new v3 ledger.
+type Ledger3Config struct {
+	Writer      io.Writer
+	Environment map[string]any
+	Hashes      []string   // hash algorithm names in order
+	Schemas     []string   // schema URLs in order
+}
+
+var defaultSchemas = []string{
+	"https://github.com/buildwarden/buildwarden/schemas/http-open.json",
+	"https://github.com/buildwarden/buildwarden/schemas/http-headers.json",
+	"https://github.com/buildwarden/buildwarden/schemas/http-body.json",
+	"https://github.com/buildwarden/buildwarden/schemas/artifact.json",
+	"https://github.com/buildwarden/buildwarden/schemas/redacted.json",
+}
+
+// NewLedger3 creates a new binary ledger, writes the header, and starts the
+// serialization loop. The returned Ledger3 is ready for Open/Checkpoint/Close/Artifact calls.
+func NewLedger3(cfg Ledger3Config) (*Ledger3, error) {
+	if cfg.Hashes == nil {
+		cfg.Hashes = defaultHashes
+	}
+	if cfg.Schemas == nil {
+		cfg.Schemas = defaultSchemas
+	}
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate key: %w", err)
+	}
+
+	hashBlockSize := 0
+	for _, name := range cfg.Hashes {
+		hashBlockSize += hashOutputSize(name)
+	}
+
+	l := &Ledger3{
+		key:           priv,
+		writer:        cfg.Writer,
+		entries:       make(chan entry3Request, 256),
+		done:          make(chan struct{}),
+		hashes:        cfg.Hashes,
+		sigSize:       ed25519.SignatureSize, // 64
+		hashBlockSize: hashBlockSize,
+		sigBuf:        make([]byte, 0, 512),
+	}
+
+	if err := l.writeHeader(cfg); err != nil {
+		return nil, err
+	}
+
+	go l.loop()
+	return l, nil
+}
+
+// PublicKey returns the raw Ed25519 public key bytes.
+func (l *Ledger3) PublicKey() ed25519.PublicKey {
+	return l.key.Public().(ed25519.PublicKey)
+}
+
+// Open writes an open record synchronously and returns the record's raw signature
+// (the channel identifier).
+func (l *Ledger3) Open(schemaIndex byte, metadata []byte) []byte {
+	result := make(chan []byte, 1)
+	l.entries <- entry3Request{
+		entry: entry3Input{
+			Type:        RecordOpen,
+			PayloadSize: 0,
+			SchemaIndex: schemaIndex,
+			Metadata:    metadata,
+		},
+		result: result,
+	}
+	return <-result
+}
+
+// Checkpoint writes a checkpoint record (fire-and-forget).
+func (l *Ledger3) Checkpoint(openSig []byte, payloadSize int64, hashBlock []byte, schemaIndex byte, metadata []byte) {
+	l.entries <- entry3Request{
+		entry: entry3Input{
+			Type:        RecordCheckpoint,
+			OpenSig:     openSig,
+			PayloadSize: payloadSize,
+			HashBlock:   hashBlock,
+			SchemaIndex: schemaIndex,
+			Metadata:    metadata,
+		},
+	}
+}
+
+// Close writes a close record (fire-and-forget).
+func (l *Ledger3) Close(openSig []byte, payloadSize int64, hashBlock []byte, schemaIndex byte, metadata []byte) {
+	l.entries <- entry3Request{
+		entry: entry3Input{
+			Type:        RecordClose,
+			OpenSig:     openSig,
+			PayloadSize: payloadSize,
+			HashBlock:   hashBlock,
+			SchemaIndex: schemaIndex,
+			Metadata:    metadata,
+		},
+	}
+}
+
+// Artifact writes an artifact record (fire-and-forget). Closes the channel.
+func (l *Ledger3) Artifact(openSig []byte, payloadSize int64, hashBlock []byte, schemaIndex byte, metadata []byte) {
+	l.entries <- entry3Request{
+		entry: entry3Input{
+			Type:        RecordArtifact,
+			OpenSig:     openSig,
+			PayloadSize: payloadSize,
+			HashBlock:   hashBlock,
+			SchemaIndex: schemaIndex,
+			Metadata:    metadata,
+		},
+	}
+}
+
+// Finish drains the entry channel and waits for the loop to exit.
+func (l *Ledger3) Finish() {
+	close(l.entries)
+	<-l.done
+}
+
+// ComputeHashBlock computes the concatenated hash block for the given data.
+func (l *Ledger3) ComputeHashBlock(data []byte) []byte {
+	block := make([]byte, 0, l.hashBlockSize)
+	for _, name := range l.hashes {
+		h := newHash(name)
+		h.Write(data)
+		block = h.Sum(block)
+	}
+	return block
+}
+
+// --- internal ---
+
+func (l *Ledger3) writeHeader(cfg Ledger3Config) error {
+	pub := l.PublicKey()
+
+	// Build binary prefix
+	var prefix []byte
+	// Magic + version
+	prefix = append(prefix, 'B', 'L', 'D', 'L', 0x03)
+	// Signature scheme (null-terminated)
+	prefix = append(prefix, []byte("ed25519-sha512")...)
+	prefix = append(prefix, 0x00)
+	// Signature size (uint16 big-endian)
+	prefix = binary.BigEndian.AppendUint16(prefix, uint16(l.sigSize))
+	// Hash block size (uint16 big-endian)
+	prefix = binary.BigEndian.AppendUint16(prefix, uint16(l.hashBlockSize))
+	// Public key length (uint16 big-endian)
+	prefix = binary.BigEndian.AppendUint16(prefix, uint16(len(pub)))
+	// Public key bytes
+	prefix = append(prefix, pub...)
+
+	// Sign the binary prefix
+	sig := l.sign(prefix)
+	l.prevSigRaw = sig
+
+	// Encode header CBOR metadata
+	meta := Ledger3HeaderMeta{
+		Hashes:      cfg.Hashes,
+		Schemas:     cfg.Schemas,
+		Environment: cfg.Environment,
+	}
+	metaBytes, err := cbor.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("encode header metadata: %w", err)
+	}
+
+	// Write: prefix + signature + metadata-length + metadata
+	var buf []byte
+	buf = append(buf, prefix...)
+	buf = append(buf, sig...)
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(metaBytes)))
+	buf = append(buf, metaBytes...)
+
+	if _, err := l.writer.Write(buf); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+	return nil
+}
+
+func (l *Ledger3) loop() {
+	defer close(l.done)
+
+	for req := range l.entries {
+		e := req.entry
+		l.seq.Add(1)
+
+		// Build signature input
+		l.sigBuf = l.sigBuf[:0]
+		l.sigBuf = append(l.sigBuf, e.Type)
+		l.sigBuf = append(l.sigBuf, l.prevSigRaw...)
+
+		if e.Type != RecordOpen {
+			l.sigBuf = append(l.sigBuf, e.OpenSig...)
+		}
+
+		l.sigBuf = binary.BigEndian.AppendUint64(l.sigBuf, uint64(e.PayloadSize))
+
+		if e.PayloadSize != 0 {
+			l.sigBuf = append(l.sigBuf, e.HashBlock...)
+		}
+
+		sig := l.sign(l.sigBuf)
+
+		// Write record bytes
+		var rec []byte
+		rec = append(rec, e.Type)
+		rec = append(rec, l.prevSigRaw...)
+		if e.Type != RecordOpen {
+			rec = append(rec, e.OpenSig...)
+		}
+		rec = binary.BigEndian.AppendUint64(rec, uint64(e.PayloadSize))
+		if e.PayloadSize != 0 {
+			rec = append(rec, e.HashBlock...)
+		}
+		rec = append(rec, sig...)
+		rec = append(rec, e.SchemaIndex)
+
+		if e.SchemaIndex != SchemaNoMetadata {
+			rec = binary.BigEndian.AppendUint32(rec, uint32(len(e.Metadata)))
+			rec = append(rec, e.Metadata...)
+		}
+
+		if _, err := l.writer.Write(rec); err != nil {
+			log.Printf("error writing ledger3 record: %v", err)
+		}
+
+		l.prevSigRaw = sig
+		if req.result != nil {
+			req.result <- sig
+		}
+	}
+}
+
+func (l *Ledger3) sign(input []byte) []byte {
+	digest := sha512.Sum512(input)
+	return ed25519.Sign(l.key, digest[:])
+}
+
+func hashOutputSize(name string) int {
+	switch name {
+	case "blake2b_256":
+		return blake2b.Size256
+	case "sha256":
+		return 32
+	case "sha1":
+		return 20
+	case "md5":
+		return 16
+	default:
+		panic("unsupported hash: " + name)
+	}
+}
+
+// HashData computes individual hashes for data, returning them in order.
+// Useful for callers that need both the hash block and individual hex values.
+func HashData(data []byte, hashes []string) [][]byte {
+	result := make([][]byte, len(hashes))
+	for i, name := range hashes {
+		h := newHash(name)
+		h.Write(data)
+		result[i] = h.Sum(nil)
+	}
+	return result
+}
+
+// StreamingHasher computes all configured hashes incrementally.
+type StreamingHasher struct {
+	hashes []hash.Hash
+	size   int64
+}
+
+// NewStreamingHasher creates a hasher for the given algorithm names.
+func NewStreamingHasher(names []string) *StreamingHasher {
+	h := &StreamingHasher{hashes: make([]hash.Hash, len(names))}
+	for i, name := range names {
+		h.hashes[i] = newHash(name)
+	}
+	return h
+}
+
+func (s *StreamingHasher) Write(p []byte) (int, error) {
+	for _, h := range s.hashes {
+		h.Write(p)
+	}
+	s.size += int64(len(p))
+	return len(p), nil
+}
+
+// Finish returns the concatenated hash block and total bytes written.
+func (s *StreamingHasher) Finish() (hashBlock []byte, size int64) {
+	for _, h := range s.hashes {
+		hashBlock = h.Sum(hashBlock)
+	}
+	return hashBlock, s.size
+}

--- a/relay/ledger3_read.go
+++ b/relay/ledger3_read.go
@@ -1,0 +1,315 @@
+package relay
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha512"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+// Ledger3Header holds the parsed header of a v3 binary ledger.
+type Ledger3Header struct {
+	Version       byte
+	SigScheme     string
+	SigSize       int
+	HashBlockSize int
+	PubKeyLen     int
+	PubKey        []byte
+	Signature     []byte
+	Meta          Ledger3HeaderMeta
+	PrefixBytes   []byte // raw binary prefix (for signature verification)
+}
+
+// Ledger3Record holds a parsed record from a v3 binary ledger.
+type Ledger3Record struct {
+	Type        byte
+	PrevSig     []byte
+	OpenSig     []byte // nil for open records
+	PayloadSize int64
+	HashBlock   []byte // nil when PayloadSize == 0
+	Signature   []byte
+	SchemaIndex byte
+	Metadata    []byte // raw CBOR bytes; nil when SchemaIndex == 0xFF
+}
+
+// Direction returns "in", "out", or "" based on the payload size sign.
+func (r *Ledger3Record) Direction() string {
+	if r.PayloadSize > 0 {
+		return "in"
+	}
+	if r.PayloadSize < 0 {
+		return "out"
+	}
+	return ""
+}
+
+// AbsPayloadSize returns the absolute value of the payload size.
+func (r *Ledger3Record) AbsPayloadSize() int64 {
+	if r.PayloadSize < 0 {
+		return -r.PayloadSize
+	}
+	return r.PayloadSize
+}
+
+// TypeName returns the human-readable record type name.
+func (r *Ledger3Record) TypeName() string {
+	switch r.Type {
+	case RecordOpen:
+		return "open"
+	case RecordCheckpoint:
+		return "checkpoint"
+	case RecordClose:
+		return "close"
+	case RecordArtifact:
+		return "artifact"
+	default:
+		return fmt.Sprintf("unknown(0x%02x)", r.Type)
+	}
+}
+
+// Ledger3VerifyResult holds the outcome of verifying a v3 ledger.
+type Ledger3VerifyResult struct {
+	Header       Ledger3Header
+	Records      []Ledger3Record
+	Valid        bool
+	SigErrors    int
+	Unclosed     int
+	TotalRecords int
+}
+
+// ReadLedger3Header parses the header from a v3 binary ledger.
+// Returns the header and the number of bytes consumed.
+func ReadLedger3Header(data []byte) (*Ledger3Header, int, error) {
+	if len(data) < 5 {
+		return nil, 0, errors.New("data too short for magic+version")
+	}
+	if string(data[0:4]) != "BLDL" {
+		return nil, 0, errors.New("invalid magic bytes")
+	}
+
+	h := &Ledger3Header{Version: data[4]}
+	off := 5
+
+	// Signature scheme (null-terminated)
+	nullIdx := bytes.IndexByte(data[off:], 0x00)
+	if nullIdx < 0 {
+		return nil, 0, errors.New("no null terminator for signature scheme")
+	}
+	h.SigScheme = string(data[off : off+nullIdx])
+	off += nullIdx + 1
+
+	// Sizes
+	if off+6 > len(data) {
+		return nil, 0, errors.New("data too short for size fields")
+	}
+	h.SigSize = int(binary.BigEndian.Uint16(data[off:]))
+	off += 2
+	h.HashBlockSize = int(binary.BigEndian.Uint16(data[off:]))
+	off += 2
+	h.PubKeyLen = int(binary.BigEndian.Uint16(data[off:]))
+	off += 2
+
+	// Public key
+	if off+h.PubKeyLen > len(data) {
+		return nil, 0, errors.New("data too short for public key")
+	}
+	h.PubKey = make([]byte, h.PubKeyLen)
+	copy(h.PubKey, data[off:off+h.PubKeyLen])
+	off += h.PubKeyLen
+
+	h.PrefixBytes = data[:off]
+
+	// Header signature
+	if off+h.SigSize > len(data) {
+		return nil, 0, errors.New("data too short for header signature")
+	}
+	h.Signature = make([]byte, h.SigSize)
+	copy(h.Signature, data[off:off+h.SigSize])
+	off += h.SigSize
+
+	// CBOR metadata
+	if off+4 > len(data) {
+		return nil, 0, errors.New("data too short for metadata length")
+	}
+	metaLen := int(binary.BigEndian.Uint32(data[off:]))
+	off += 4
+	if off+metaLen > len(data) {
+		return nil, 0, errors.New("data too short for metadata")
+	}
+	if err := cbor.Unmarshal(data[off:off+metaLen], &h.Meta); err != nil {
+		return nil, 0, fmt.Errorf("decode header metadata: %w", err)
+	}
+	off += metaLen
+
+	return h, off, nil
+}
+
+// ReadLedger3Record parses a single record from data at the given offset.
+// Returns the record and the number of bytes consumed.
+func ReadLedger3Record(data []byte, sigSize, hashBlockSize int) (*Ledger3Record, int, error) {
+	if len(data) < 1 {
+		return nil, 0, io.EOF
+	}
+
+	r := &Ledger3Record{Type: data[0]}
+	off := 1
+
+	// Previous signature
+	if off+sigSize > len(data) {
+		return nil, 0, errors.New("data too short for prev_sig")
+	}
+	r.PrevSig = make([]byte, sigSize)
+	copy(r.PrevSig, data[off:off+sigSize])
+	off += sigSize
+
+	// Open signature (not present for open records)
+	if r.Type != RecordOpen {
+		if off+sigSize > len(data) {
+			return nil, 0, errors.New("data too short for open_sig")
+		}
+		r.OpenSig = make([]byte, sigSize)
+		copy(r.OpenSig, data[off:off+sigSize])
+		off += sigSize
+	}
+
+	// Payload size
+	if off+8 > len(data) {
+		return nil, 0, errors.New("data too short for payload_size")
+	}
+	r.PayloadSize = int64(binary.BigEndian.Uint64(data[off:]))
+	off += 8
+
+	// Hash block (only when payload != 0)
+	if r.PayloadSize != 0 {
+		if off+hashBlockSize > len(data) {
+			return nil, 0, errors.New("data too short for hash_block")
+		}
+		r.HashBlock = make([]byte, hashBlockSize)
+		copy(r.HashBlock, data[off:off+hashBlockSize])
+		off += hashBlockSize
+	}
+
+	// Record signature
+	if off+sigSize > len(data) {
+		return nil, 0, errors.New("data too short for record signature")
+	}
+	r.Signature = make([]byte, sigSize)
+	copy(r.Signature, data[off:off+sigSize])
+	off += sigSize
+
+	// Schema index
+	if off >= len(data) {
+		return nil, 0, errors.New("data too short for schema index")
+	}
+	r.SchemaIndex = data[off]
+	off++
+
+	// Metadata (if present)
+	if r.SchemaIndex != SchemaNoMetadata {
+		if off+4 > len(data) {
+			return nil, 0, errors.New("data too short for metadata length")
+		}
+		metaLen := int(binary.BigEndian.Uint32(data[off:]))
+		off += 4
+		if off+metaLen > len(data) {
+			return nil, 0, errors.New("data too short for metadata")
+		}
+		r.Metadata = make([]byte, metaLen)
+		copy(r.Metadata, data[off:off+metaLen])
+		off += metaLen
+	}
+
+	return r, off, nil
+}
+
+// VerifyLedger3 parses and verifies an entire v3 binary ledger.
+func VerifyLedger3(data []byte) (*Ledger3VerifyResult, error) {
+	header, off, err := ReadLedger3Header(data)
+	if err != nil {
+		return nil, fmt.Errorf("read header: %w", err)
+	}
+
+	result := &Ledger3VerifyResult{Header: *header}
+
+	// Verify header signature
+	if !verifyEd25519Sig(header.PubKey, header.PrefixBytes, header.Signature) {
+		result.SigErrors++
+	}
+
+	prevSig := header.Signature
+	openChannels := make(map[string]bool) // track open channels by hex(open_sig)
+
+	for off < len(data) {
+		rec, n, err := ReadLedger3Record(data[off:], header.SigSize, header.HashBlockSize)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("read record %d: %w", result.TotalRecords, err)
+		}
+		off += n
+		result.TotalRecords++
+
+		// Verify prev_sig matches chain
+		if !bytes.Equal(rec.PrevSig, prevSig) {
+			result.SigErrors++
+		}
+
+		// Reconstruct signature input and verify
+		sigInput := buildRecordSigInput(rec)
+		if !verifyEd25519Sig(header.PubKey, sigInput, rec.Signature) {
+			result.SigErrors++
+		}
+
+		// Track channel state
+		sigKey := string(rec.Signature)
+		switch rec.Type {
+		case RecordOpen:
+			openChannels[sigKey] = true
+		case RecordClose, RecordArtifact:
+			if rec.OpenSig != nil {
+				delete(openChannels, string(rec.OpenSig))
+			}
+		}
+
+		result.Records = append(result.Records, *rec)
+		prevSig = rec.Signature
+	}
+
+	result.Unclosed = len(openChannels)
+	result.Valid = result.SigErrors == 0
+
+	return result, nil
+}
+
+// IsLedger3 checks if data begins with the v3 magic bytes.
+func IsLedger3(data []byte) bool {
+	return len(data) >= 5 && string(data[0:4]) == "BLDL" && data[4] == 0x03
+}
+
+func buildRecordSigInput(r *Ledger3Record) []byte {
+	var buf []byte
+	buf = append(buf, r.Type)
+	buf = append(buf, r.PrevSig...)
+	if r.Type != RecordOpen {
+		buf = append(buf, r.OpenSig...)
+	}
+	buf = binary.BigEndian.AppendUint64(buf, uint64(r.PayloadSize))
+	if r.PayloadSize != 0 {
+		buf = append(buf, r.HashBlock...)
+	}
+	return buf
+}
+
+func verifyEd25519Sig(pubKey, input, sig []byte) bool {
+	if len(pubKey) != ed25519.PublicKeySize {
+		return false
+	}
+	digest := sha512.Sum512(input)
+	return ed25519.Verify(ed25519.PublicKey(pubKey), digest[:], sig)
+}

--- a/relay/ledger3_read_test.go
+++ b/relay/ledger3_read_test.go
@@ -1,0 +1,286 @@
+package relay
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+func TestLedger3ReadHeader(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "test"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+	l.Finish()
+
+	h, _, err := ReadLedger3Header(buf.Bytes())
+	if err != nil {
+		t.Fatalf("ReadLedger3Header: %v", err)
+	}
+	if h.Version != 0x03 {
+		t.Errorf("version = %d, want 3", h.Version)
+	}
+	if h.SigScheme != "ed25519-sha512" {
+		t.Errorf("scheme = %q", h.SigScheme)
+	}
+	if h.SigSize != 64 {
+		t.Errorf("sigSize = %d", h.SigSize)
+	}
+	if h.HashBlockSize != 100 {
+		t.Errorf("hashBlockSize = %d", h.HashBlockSize)
+	}
+	if len(h.Meta.Hashes) != 4 {
+		t.Errorf("meta hashes = %d", len(h.Meta.Hashes))
+	}
+	if len(h.Meta.Schemas) != 5 {
+		t.Errorf("meta schemas = %d", len(h.Meta.Schemas))
+	}
+}
+
+func TestLedger3VerifyBasicFlow(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "test"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+
+	openSig := l.Open(SchemaNoMetadata, nil)
+	body := []byte("response data")
+	hb := l.ComputeHashBlock(body)
+	l.Close(openSig, int64(len(body)), hb, SchemaNoMetadata, nil)
+	l.Finish()
+
+	result, err := VerifyLedger3(buf.Bytes())
+	if err != nil {
+		t.Fatalf("VerifyLedger3: %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("ledger invalid, sigErrors=%d", result.SigErrors)
+	}
+	if result.TotalRecords != 2 {
+		t.Fatalf("records = %d, want 2", result.TotalRecords)
+	}
+	if result.Unclosed != 0 {
+		t.Fatalf("unclosed = %d", result.Unclosed)
+	}
+}
+
+func TestLedger3VerifyHTTPFlow(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "container"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+
+	// Open with http-open metadata
+	openMeta, _ := cbor.Marshal(map[string]any{
+		"method": "GET", "url": "https://example.com/pkg.tar.gz", "protocol": "HTTP/1.1",
+	})
+	openSig := l.Open(0, openMeta)
+
+	// Checkpoint: request headers out
+	reqHeaders := []byte("GET /pkg.tar.gz HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	hb1 := l.ComputeHashBlock(reqHeaders)
+	headersMeta, _ := cbor.Marshal(map[string]any{
+		"headers": [][]string{{"X-Request-Id", "abc123"}},
+	})
+	l.Checkpoint(openSig, -int64(len(reqHeaders)), hb1, 1, headersMeta)
+
+	// Checkpoint: response headers in
+	respHeaders := []byte("HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\n")
+	hb2 := l.ComputeHashBlock(respHeaders)
+	l.Checkpoint(openSig, int64(len(respHeaders)), hb2, 1, headersMeta)
+
+	// Close: response body in
+	body := []byte("hello world")
+	hb3 := l.ComputeHashBlock(body)
+	bodyMeta, _ := cbor.Marshal(map[string]any{"status": 200})
+	l.Close(openSig, int64(len(body)), hb3, 2, bodyMeta)
+
+	l.Finish()
+
+	result, err := VerifyLedger3(buf.Bytes())
+	if err != nil {
+		t.Fatalf("VerifyLedger3: %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("ledger invalid, sigErrors=%d", result.SigErrors)
+	}
+	if result.TotalRecords != 4 {
+		t.Fatalf("records = %d, want 4", result.TotalRecords)
+	}
+	if result.Unclosed != 0 {
+		t.Fatalf("unclosed = %d", result.Unclosed)
+	}
+
+	// Verify record types
+	expected := []byte{RecordOpen, RecordCheckpoint, RecordCheckpoint, RecordClose}
+	for i, rec := range result.Records {
+		if rec.Type != expected[i] {
+			t.Errorf("record %d type = 0x%02x, want 0x%02x", i, rec.Type, expected[i])
+		}
+	}
+
+	// Verify directions
+	if result.Records[1].Direction() != "out" {
+		t.Errorf("record 1 direction = %q, want out", result.Records[1].Direction())
+	}
+	if result.Records[2].Direction() != "in" {
+		t.Errorf("record 2 direction = %q, want in", result.Records[2].Direction())
+	}
+	if result.Records[3].Direction() != "in" {
+		t.Errorf("record 3 direction = %q, want in", result.Records[3].Direction())
+	}
+}
+
+func TestLedger3VerifyArtifact(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "test"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+
+	openSig := l.Open(SchemaNoMetadata, nil)
+	artifact := []byte("build output binary")
+	hb := l.ComputeHashBlock(artifact)
+	meta, _ := cbor.Marshal(map[string]any{"name": "app", "context": map[string]any{}})
+	l.Artifact(openSig, -int64(len(artifact)), hb, 3, meta)
+	l.Finish()
+
+	result, err := VerifyLedger3(buf.Bytes())
+	if err != nil {
+		t.Fatalf("VerifyLedger3: %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("ledger invalid, sigErrors=%d", result.SigErrors)
+	}
+	if result.Unclosed != 0 {
+		t.Fatalf("unclosed = %d, want 0", result.Unclosed)
+	}
+	if result.Records[1].Type != RecordArtifact {
+		t.Fatalf("record 1 type = 0x%02x, want artifact", result.Records[1].Type)
+	}
+}
+
+func TestLedger3VerifyTamperDetection(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "test"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+
+	openSig := l.Open(SchemaNoMetadata, nil)
+	body := []byte("data")
+	hb := l.ComputeHashBlock(body)
+	l.Close(openSig, int64(len(body)), hb, SchemaNoMetadata, nil)
+	l.Finish()
+
+	// Tamper: flip a byte in the middle of the ledger
+	data := buf.Bytes()
+	tampered := make([]byte, len(data))
+	copy(tampered, data)
+	tampered[len(tampered)/2] ^= 0xFF
+
+	result, err := VerifyLedger3(tampered)
+	if err != nil {
+		// Parse error is acceptable for tampered data
+		return
+	}
+	if result.Valid {
+		t.Fatal("tampered ledger should not verify as valid")
+	}
+	if result.SigErrors == 0 {
+		t.Fatal("expected signature errors for tampered ledger")
+	}
+}
+
+func TestLedger3VerifyMultipleChannels(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "test"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+
+	sig1 := l.Open(SchemaNoMetadata, nil)
+	sig2 := l.Open(SchemaNoMetadata, nil)
+
+	body1 := []byte("first")
+	body2 := []byte("second")
+	l.Close(sig2, int64(len(body2)), l.ComputeHashBlock(body2), SchemaNoMetadata, nil)
+	l.Close(sig1, int64(len(body1)), l.ComputeHashBlock(body1), SchemaNoMetadata, nil)
+	l.Finish()
+
+	result, err := VerifyLedger3(buf.Bytes())
+	if err != nil {
+		t.Fatalf("VerifyLedger3: %v", err)
+	}
+	if !result.Valid {
+		t.Fatalf("ledger invalid, sigErrors=%d", result.SigErrors)
+	}
+	if result.TotalRecords != 4 {
+		t.Fatalf("records = %d, want 4", result.TotalRecords)
+	}
+	if result.Unclosed != 0 {
+		t.Fatalf("unclosed = %d", result.Unclosed)
+	}
+}
+
+func TestLedger3IsLedger3(t *testing.T) {
+	if IsLedger3([]byte("BLDL\x03rest")) != true {
+		t.Error("should detect v3")
+	}
+	if IsLedger3([]byte(`{"entry_type":"header"`)) != false {
+		t.Error("should not detect JSON as v3")
+	}
+	if IsLedger3([]byte("BLD")) != false {
+		t.Error("should not detect short data as v3")
+	}
+}
+
+func TestLedger3RecordHelpers(t *testing.T) {
+	r := &Ledger3Record{PayloadSize: 100}
+	if r.Direction() != "in" {
+		t.Errorf("positive direction = %q", r.Direction())
+	}
+	if r.AbsPayloadSize() != 100 {
+		t.Errorf("abs = %d", r.AbsPayloadSize())
+	}
+
+	r.PayloadSize = -50
+	if r.Direction() != "out" {
+		t.Errorf("negative direction = %q", r.Direction())
+	}
+	if r.AbsPayloadSize() != 50 {
+		t.Errorf("abs = %d", r.AbsPayloadSize())
+	}
+
+	r.PayloadSize = 0
+	if r.Direction() != "" {
+		t.Errorf("zero direction = %q", r.Direction())
+	}
+
+	r.Type = RecordArtifact
+	if r.TypeName() != "artifact" {
+		t.Errorf("typeName = %q", r.TypeName())
+	}
+}

--- a/relay/ledger3_test.go
+++ b/relay/ledger3_test.go
@@ -1,0 +1,318 @@
+package relay
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha512"
+	"encoding/binary"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+func TestLedger3Header(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "container", "digest": "sha256:abc"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+	l.Finish()
+
+	data := buf.Bytes()
+
+	// Magic
+	if string(data[0:4]) != "BLDL" {
+		t.Fatalf("magic = %q, want BLDL", data[0:4])
+	}
+	if data[4] != 0x03 {
+		t.Fatalf("version = %d, want 3", data[4])
+	}
+
+	// Signature scheme (null-terminated)
+	schemeEnd := bytes.IndexByte(data[5:], 0x00)
+	if schemeEnd < 0 {
+		t.Fatal("no null terminator for signature scheme")
+	}
+	scheme := string(data[5 : 5+schemeEnd])
+	if scheme != "ed25519-sha512" {
+		t.Fatalf("scheme = %q, want ed25519-sha512", scheme)
+	}
+	off := 5 + schemeEnd + 1
+
+	// Sizes
+	sigSize := binary.BigEndian.Uint16(data[off:])
+	off += 2
+	hashBlockSize := binary.BigEndian.Uint16(data[off:])
+	off += 2
+	pubKeyLen := binary.BigEndian.Uint16(data[off:])
+	off += 2
+
+	if sigSize != 64 {
+		t.Fatalf("sigSize = %d, want 64", sigSize)
+	}
+	if hashBlockSize != 100 { // 32+32+20+16
+		t.Fatalf("hashBlockSize = %d, want 100", hashBlockSize)
+	}
+	if pubKeyLen != 32 {
+		t.Fatalf("pubKeyLen = %d, want 32", pubKeyLen)
+	}
+
+	// Public key
+	pubKey := data[off : off+int(pubKeyLen)]
+	off += int(pubKeyLen)
+	prefixEnd := off
+
+	if !bytes.Equal(pubKey, []byte(l.PublicKey())) {
+		t.Fatal("public key mismatch")
+	}
+
+	// Verify header signature
+	sig := data[off : off+int(sigSize)]
+	off += int(sigSize)
+
+	digest := sha512.Sum512(data[:prefixEnd])
+	if !ed25519.Verify(l.PublicKey(), digest[:], sig) {
+		t.Fatal("header signature verification failed")
+	}
+
+	// CBOR metadata
+	metaLen := binary.BigEndian.Uint32(data[off:])
+	off += 4
+	metaBytes := data[off : off+int(metaLen)]
+
+	var meta Ledger3HeaderMeta
+	if err := cbor.Unmarshal(metaBytes, &meta); err != nil {
+		t.Fatalf("unmarshal header meta: %v", err)
+	}
+	if len(meta.Hashes) != 4 {
+		t.Fatalf("meta.Hashes len = %d, want 4", len(meta.Hashes))
+	}
+	if len(meta.Schemas) != 5 {
+		t.Fatalf("meta.Schemas len = %d, want 5", len(meta.Schemas))
+	}
+}
+
+func TestLedger3BasicFlow(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "test"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+
+	// Open
+	openSig := l.Open(SchemaNoMetadata, nil)
+	if len(openSig) != 64 {
+		t.Fatalf("open sig len = %d, want 64", len(openSig))
+	}
+
+	// Checkpoint out (request headers)
+	headers := []byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	hb := l.ComputeHashBlock(headers)
+	l.Checkpoint(openSig, -int64(len(headers)), hb, SchemaNoMetadata, nil)
+
+	// Close in (response body)
+	body := []byte("hello world")
+	hb2 := l.ComputeHashBlock(body)
+	l.Close(openSig, int64(len(body)), hb2, SchemaNoMetadata, nil)
+
+	l.Finish()
+
+	// Verify the full signature chain
+	verifyLedger3Chain(t, buf.Bytes(), l.PublicKey())
+}
+
+func TestLedger3Artifact(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "test"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+
+	openSig := l.Open(SchemaNoMetadata, nil)
+
+	// Artifact with payload
+	artifact := []byte("binary content")
+	hb := l.ComputeHashBlock(artifact)
+	meta, _ := cbor.Marshal(map[string]any{"name": "output.bin", "context": map[string]any{}})
+	l.Artifact(openSig, -int64(len(artifact)), hb, 3, meta) // schema index 3 = artifact
+
+	l.Finish()
+	verifyLedger3Chain(t, buf.Bytes(), l.PublicKey())
+}
+
+func TestLedger3EmptyArtifact(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "test"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+
+	openSig := l.Open(SchemaNoMetadata, nil)
+
+	// Empty artifact (payload=0, no hash block)
+	meta, _ := cbor.Marshal(map[string]any{"name": "marker", "context": map[string]any{}})
+	l.Artifact(openSig, 0, nil, 3, meta)
+
+	l.Finish()
+	verifyLedger3Chain(t, buf.Bytes(), l.PublicKey())
+}
+
+func TestLedger3WithMetadata(t *testing.T) {
+	var buf bytes.Buffer
+	l, err := NewLedger3(Ledger3Config{
+		Writer:      &buf,
+		Environment: map[string]any{"type": "test"},
+	})
+	if err != nil {
+		t.Fatalf("NewLedger3: %v", err)
+	}
+
+	openMeta, _ := cbor.Marshal(map[string]any{
+		"method": "GET", "url": "https://example.com/file", "protocol": "HTTP/1.1",
+	})
+	openSig := l.Open(0, openMeta) // schema index 0 = http-open
+
+	body := []byte("response")
+	hb := l.ComputeHashBlock(body)
+	bodyMeta, _ := cbor.Marshal(map[string]any{"status": 200})
+	l.Close(openSig, int64(len(body)), hb, 2, bodyMeta) // schema index 2 = http-body
+
+	l.Finish()
+	verifyLedger3Chain(t, buf.Bytes(), l.PublicKey())
+}
+
+func TestLedger3StreamingHasher(t *testing.T) {
+	data := []byte("hello world, this is a streaming hash test")
+
+	// Compute via streaming
+	sh := NewStreamingHasher(defaultHashes)
+	sh.Write(data[:10])
+	sh.Write(data[10:])
+	block, size := sh.Finish()
+
+	if size != int64(len(data)) {
+		t.Fatalf("size = %d, want %d", size, len(data))
+	}
+
+	// Compute via one-shot for comparison
+	var expected []byte
+	for _, name := range defaultHashes {
+		h := newHash(name)
+		h.Write(data)
+		expected = h.Sum(expected)
+	}
+
+	if !bytes.Equal(block, expected) {
+		t.Fatal("streaming hash block doesn't match one-shot")
+	}
+}
+
+// verifyLedger3Chain parses the binary ledger and verifies every signature.
+func verifyLedger3Chain(t *testing.T, data []byte, pubKey ed25519.PublicKey) {
+	t.Helper()
+	off := 0
+
+	// Parse header
+	if string(data[off:off+4]) != "BLDL" {
+		t.Fatal("bad magic")
+	}
+	off += 5 // magic + version
+
+	// Signature scheme
+	nullIdx := bytes.IndexByte(data[off:], 0x00)
+	off += nullIdx + 1
+
+	sigSize := int(binary.BigEndian.Uint16(data[off:]))
+	off += 2
+	hashBlockSize := int(binary.BigEndian.Uint16(data[off:]))
+	off += 2
+	pubKeyLen := int(binary.BigEndian.Uint16(data[off:]))
+	off += 2
+	off += pubKeyLen // skip public key bytes
+	prefixEnd := off
+
+	// Verify header signature
+	headerSig := data[off : off+sigSize]
+	off += sigSize
+	digest := sha512.Sum512(data[:prefixEnd])
+	if !ed25519.Verify(pubKey, digest[:], headerSig) {
+		t.Fatal("header signature invalid")
+	}
+
+	// Skip header CBOR metadata
+	metaLen := int(binary.BigEndian.Uint32(data[off:]))
+	off += 4 + metaLen
+
+	prevSig := headerSig
+
+	// Parse records
+	recordNum := 0
+	for off < len(data) {
+		recordType := data[off]
+		off++
+
+		// Build signature input
+		var sigInput []byte
+		sigInput = append(sigInput, recordType)
+		sigInput = append(sigInput, data[off:off+sigSize]...)
+
+		// Verify prev_sig field matches
+		if !bytes.Equal(data[off:off+sigSize], prevSig) {
+			t.Fatalf("record %d: prev_sig mismatch", recordNum)
+		}
+		off += sigSize
+
+		// Open signature (not present for open records)
+		if recordType != RecordOpen {
+			sigInput = append(sigInput, data[off:off+sigSize]...)
+			off += sigSize
+		}
+
+		// Payload size
+		payloadSize := int64(binary.BigEndian.Uint64(data[off:]))
+		sigInput = binary.BigEndian.AppendUint64(sigInput, uint64(payloadSize))
+		off += 8
+
+		// Hash block (present only when payload != 0)
+		if payloadSize != 0 {
+			sigInput = append(sigInput, data[off:off+hashBlockSize]...)
+			off += hashBlockSize
+		}
+
+		// Record signature
+		recSig := data[off : off+sigSize]
+		off += sigSize
+
+		d := sha512.Sum512(sigInput)
+		if !ed25519.Verify(pubKey, d[:], recSig) {
+			t.Fatalf("record %d (type 0x%02x): signature invalid", recordNum, recordType)
+		}
+
+		// Schema index + optional metadata
+		schemaIdx := data[off]
+		off++
+		if schemaIdx != SchemaNoMetadata {
+			mLen := int(binary.BigEndian.Uint32(data[off:]))
+			off += 4 + mLen
+		}
+
+		prevSig = recSig
+		recordNum++
+	}
+
+	if recordNum == 0 {
+		t.Fatal("no records found")
+	}
+}

--- a/relay/ledger3_test.go
+++ b/relay/ledger3_test.go
@@ -198,8 +198,8 @@ func TestLedger3StreamingHasher(t *testing.T) {
 
 	// Compute via streaming
 	sh := NewStreamingHasher(defaultHashes)
-	sh.Write(data[:10])
-	sh.Write(data[10:])
+	sh.Write(data[:10])  //nolint:errcheck
+	sh.Write(data[10:])  //nolint:errcheck
 	block, size := sh.Finish()
 
 	if size != int64(len(data)) {
@@ -297,7 +297,8 @@ func verifyLedger3Chain(t *testing.T, data []byte, pubKey ed25519.PublicKey) {
 
 		d := sha512.Sum512(sigInput)
 		if !ed25519.Verify(pubKey, d[:], recSig) {
-			t.Fatalf("record %d (type 0x%02x): signature invalid", recordNum, recordType)
+			t.Fatalf("record %d (type 0x%02x): signature invalid",
+			recordNum, recordType)
 		}
 
 		// Schema index + optional metadata

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/miekg/dns"
 )
 
@@ -91,7 +92,7 @@ func CAFingerprint() string {
 
 // reqSigs maps in-flight requests to their ledger open signatures.
 var (
-	reqSigs   = make(map[*http.Request]string)
+	reqSigs   = make(map[*http.Request][]byte)
 	reqSigsMu sync.Mutex
 )
 
@@ -103,15 +104,22 @@ var reservedHosts = map[string]bool{
 // outDir is the ledger output directory, set by SetOutDir.
 var outDir string
 
-// emptyHashes are the well-known hashes of an empty payload.
-var emptyHashes = map[string]string{
-	"blake2b_256": "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-	"sha256":      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-	"sha1":        "da39a3ee5e6b4b0d3255bfef95601890afd80709",
-	"md5":         "d41d8cd98f00b204e9800998ecf8427e",
-}
+// ledger3 is the active v3 binary ledger writer.
+var ledger3Active *Ledger3
+
+// Schema indices matching the default schema list order.
+const (
+	schemaHTTPOpen    byte = 0
+	schemaHTTPHeaders byte = 1
+	schemaHTTPBody    byte = 2
+	schemaArtifact    byte = 3
+	schemaRedacted    byte = 4
+)
 
 func SetOutDir(dir string) { outDir = dir }
+
+// SetLedger3 sets the active v3 ledger writer (called from cmd/relay/main.go).
+func SetLedger3(l *Ledger3) { ledger3Active = l }
 
 func RunDns(addr net.TCPAddr) error {
 	server := &dns.Server{Addr: addr.String(), Net: "udp"}
@@ -214,7 +222,7 @@ func RunHttps(addr net.TCPAddr) error {
 }
 
 func onRequest(req *http.Request) (*http.Request, *http.Response) {
-	if ledger == nil {
+	if ledger3Active == nil {
 		return req, nil
 	}
 
@@ -225,30 +233,35 @@ func onRequest(req *http.Request) (*http.Request, *http.Response) {
 	}
 
 	// Synchronous open — blocks until signature is on the ledger.
-	openSig := ledger.Open(map[string]any{
+	openMeta, _ := cbor.Marshal(map[string]any{
 		"method":   req.Method,
 		"url":      req.URL.String(),
 		"protocol": req.Proto,
-		"host":     req.Host,
 	})
+	openSig := ledger3Active.Open(schemaHTTPOpen, openMeta)
 
-	// Checkpoint: request headers (direction: out)
+	// Checkpoint: request headers (direction: out = negative size)
 	reqHeaders, err := httputil.DumpRequest(req, false)
 	if err != nil {
 		log.Printf("error dumping request headers: %v", err)
 		reqHeaders = []byte{}
 	}
-	ledger.Checkpoint(openSig, "out", reqHeaders, nil)
+	hb := ledger3Active.ComputeHashBlock(reqHeaders)
+	headersMeta := buildHeadersMeta(req.Header)
+	ledger3Active.Checkpoint(
+		openSig, -int64(len(reqHeaders)), hb, schemaHTTPHeaders, headersMeta,
+	)
 
 	// If request has a body (POST/PUT), stream it through hashers.
 	if req.Body != nil && req.ContentLength != 0 {
-		hashers := newHasherSet(ledger.hashes)
-		req.Body = &hashingReadCloser{
-			source:  req.Body,
-			hashers: hashers,
-			onClose: func(size int64) {
-				ledger.CheckpointHashed(
-					openSig, "out", size, hashers.sums(),
+		hasher := NewStreamingHasher(ledger3Active.hashes)
+		req.Body = &hashingReadCloser3{
+			source: req.Body,
+			hasher: hasher,
+			onClose: func(hashBlock []byte, size int64) {
+				bodyMeta, _ := cbor.Marshal(map[string]any{})
+				ledger3Active.Checkpoint(
+					openSig, -size, hashBlock, schemaHTTPBody, bodyMeta,
 				)
 			},
 		}
@@ -268,20 +281,23 @@ func handleArtifactPost(req *http.Request) (*http.Request, *http.Response) {
 	}
 
 	// Record in ledger.
-	openSig := ledger.Open(map[string]any{
-		"method": "POST",
-		"url":    req.URL.String(),
-		"host":   req.Host,
-		"schema": "artifact",
-		"path":   artifactName,
+	openMeta, _ := cbor.Marshal(map[string]any{
+		"method":   "POST",
+		"url":      req.URL.String(),
+		"protocol": req.Proto,
 	})
+	openSig := ledger3Active.Open(schemaHTTPOpen, openMeta)
 
 	// Checkpoint request headers.
 	reqHeaders, err := httputil.DumpRequest(req, false)
 	if err != nil {
 		reqHeaders = []byte{}
 	}
-	ledger.Checkpoint(openSig, "out", reqHeaders, nil)
+	hb := ledger3Active.ComputeHashBlock(reqHeaders)
+	headersMeta := buildHeadersMeta(req.Header)
+	ledger3Active.Checkpoint(
+		openSig, -int64(len(reqHeaders)), hb, schemaHTTPHeaders, headersMeta,
+	)
 
 	// Stream body to disk and hash simultaneously.
 	artifactsDir := filepath.Join(outDir, "artifacts")
@@ -298,15 +314,13 @@ func handleArtifactPost(req *http.Request) (*http.Request, *http.Response) {
 		return req, resp
 	}
 
-	hashers := newHasherSet(ledger.hashes)
-	var size int64
+	hasher := NewStreamingHasher(ledger3Active.hashes)
 	buf := make([]byte, 32*1024)
 	for {
 		n, readErr := req.Body.Read(buf)
 		if n > 0 {
-			hashers.write(buf[:n])
+			hasher.Write(buf[:n]) //nolint:errcheck
 			tmpFile.Write(buf[:n]) //nolint:errcheck
-			size += int64(n)
 		}
 		if readErr != nil {
 			break
@@ -315,9 +329,10 @@ func handleArtifactPost(req *http.Request) (*http.Request, *http.Response) {
 	tmpFile.Close()
 	req.Body.Close()
 
+	hashBlock, size := hasher.Finish()
+
 	// Rename payload file to its primary hash.
-	sums := hashers.sums()
-	primaryHash := sums["sha256"]
+	primaryHash := hex.EncodeToString(hashBlock[:32]) // first hash is blake2b_256 (32 bytes)
 	payloadPath := filepath.Join(payloadsDir, primaryHash)
 	os.Rename(tmpFile.Name(), payloadPath) //nolint:errcheck
 
@@ -328,12 +343,14 @@ func handleArtifactPost(req *http.Request) (*http.Request, *http.Response) {
 		filepath.Join("..", "payloads", primaryHash), symPath,
 	)
 
-	// Record body checkpoint and close in ledger.
-	ledger.CheckpointHashed(openSig, "out", size, sums)
-	ledger.CloseHashed(openSig, "in", 0, emptyHashes,
-		map[string]any{"status": 200})
+	// Write artifact record (closes the channel).
+	artMeta, _ := cbor.Marshal(map[string]any{
+		"name":    artifactName,
+		"context": map[string]any{},
+	})
+	ledger3Active.Artifact(openSig, -size, hashBlock, schemaArtifact, artMeta)
 
-	log.Printf("artifact: stored %s (%d bytes, sha256:%s)",
+	log.Printf("artifact: stored %s (%d bytes, hash:%s)",
 		artifactName, size, primaryHash[:12])
 
 	resp := newTextResponse(req, http.StatusOK,
@@ -345,7 +362,7 @@ func handleArtifactPost(req *http.Request) (*http.Request, *http.Response) {
 func onResponse(
 	res *http.Response, req *http.Request,
 ) *http.Response {
-	if ledger == nil || res == nil {
+	if ledger3Active == nil || res == nil {
 		return res
 	}
 
@@ -361,20 +378,24 @@ func onResponse(
 		return res
 	}
 
-	// Checkpoint: response headers (direction: in)
+	// Checkpoint: response headers (direction: in = positive size)
 	respHeaders, err := httputil.DumpResponse(res, false)
 	if err != nil {
 		log.Printf("error dumping response headers: %v", err)
 		respHeaders = []byte{}
 	}
-	ledger.Checkpoint(openSig, "in", respHeaders, nil)
+	hb := ledger3Active.ComputeHashBlock(respHeaders)
+	headersMeta := buildHeadersMeta(res.Header)
+	ledger3Active.Checkpoint(
+		openSig, int64(len(respHeaders)), hb, schemaHTTPHeaders, headersMeta,
+	)
 
 	// For responses with no body (304, 204, 1xx), close immediately.
 	if res.StatusCode == http.StatusNotModified ||
 		res.StatusCode == http.StatusNoContent ||
 		(res.StatusCode >= 100 && res.StatusCode < 200) {
-		ledger.CloseHashed(openSig, "in", 0, emptyHashes,
-			map[string]any{"status": res.StatusCode})
+		bodyMeta, _ := cbor.Marshal(map[string]any{"status": res.StatusCode})
+		ledger3Active.Close(openSig, 0, nil, schemaHTTPBody, bodyMeta)
 		return res
 	}
 
@@ -382,7 +403,7 @@ func onResponse(
 	res.Body = newFairReader(res.Body, res.ContentLength)
 
 	// Stream body through hashers; close entry written on EOF.
-	res.Body = newLedgerBody(res.Body, openSig, res.StatusCode)
+	res.Body = newLedgerBody3(res.Body, openSig, res.StatusCode)
 
 	return res
 }
@@ -404,32 +425,30 @@ func newTextResponse(
 	}
 }
 
-// ledgerBody wraps a response body, streaming bytes through hashers.
-type ledgerBody struct {
+// ledgerBody3 wraps a response body, streaming bytes through hashers for v3 ledger.
+type ledgerBody3 struct {
 	source  io.ReadCloser
-	openSig string
+	openSig []byte
 	status  int
-	hashers *hasherSet
-	size    int64
+	hasher  *StreamingHasher
 	done    bool
 }
 
-func newLedgerBody(
-	source io.ReadCloser, openSig string, status int,
-) *ledgerBody {
-	return &ledgerBody{
+func newLedgerBody3(
+	source io.ReadCloser, openSig []byte, status int,
+) *ledgerBody3 {
+	return &ledgerBody3{
 		source:  source,
 		openSig: openSig,
 		status:  status,
-		hashers: newHasherSet(ledger.hashes),
+		hasher:  NewStreamingHasher(ledger3Active.hashes),
 	}
 }
 
-func (lb *ledgerBody) Read(p []byte) (int, error) {
+func (lb *ledgerBody3) Read(p []byte) (int, error) {
 	n, err := lb.source.Read(p)
 	if n > 0 {
-		lb.hashers.write(p[:n])
-		lb.size += int64(n)
+		lb.hasher.Write(p[:n]) //nolint:errcheck
 	}
 	if err == io.EOF && !lb.done {
 		lb.done = true
@@ -438,15 +457,14 @@ func (lb *ledgerBody) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func (lb *ledgerBody) Close() error {
+func (lb *ledgerBody3) Close() error {
 	if !lb.done {
 		lb.done = true
 		buf := make([]byte, 32*1024)
 		for {
 			n, err := lb.source.Read(buf)
 			if n > 0 {
-				lb.hashers.write(buf[:n])
-				lb.size += int64(n)
+				lb.hasher.Write(buf[:n]) //nolint:errcheck
 			}
 			if err != nil {
 				break
@@ -457,11 +475,10 @@ func (lb *ledgerBody) Close() error {
 	return lb.source.Close()
 }
 
-func (lb *ledgerBody) finish() {
-	metadata := map[string]any{"status": lb.status}
-	ledger.CloseHashed(
-		lb.openSig, "in", lb.size, lb.hashers.sums(), metadata,
-	)
+func (lb *ledgerBody3) finish() {
+	hashBlock, size := lb.hasher.Finish()
+	bodyMeta, _ := cbor.Marshal(map[string]any{"status": lb.status})
+	ledger3Active.Close(lb.openSig, size, hashBlock, schemaHTTPBody, bodyMeta)
 }
 
 // hasherSet runs multiple hash algorithms in parallel via goroutines.
@@ -507,43 +524,102 @@ func (hs *hasherSet) sums() map[string]string {
 	return result
 }
 
-// hashingReadCloser wraps a request body, hashing bytes as they are read.
-type hashingReadCloser struct {
+// hashingReadCloser3 wraps a request body, hashing bytes as they are read (v3).
+type hashingReadCloser3 struct {
 	source  io.ReadCloser
-	hashers *hasherSet
-	size    int64
-	onClose func(int64)
+	hasher  *StreamingHasher
+	onClose func(hashBlock []byte, size int64)
 	done    bool
 }
 
-func (h *hashingReadCloser) Read(p []byte) (int, error) {
+func (h *hashingReadCloser3) Read(p []byte) (int, error) {
 	n, err := h.source.Read(p)
 	if n > 0 {
-		h.hashers.write(p[:n])
-		h.size += int64(n)
+		h.hasher.Write(p[:n]) //nolint:errcheck
 	}
 	if err == io.EOF && !h.done {
 		h.done = true
-		h.onClose(h.size)
+		hashBlock, size := h.hasher.Finish()
+		h.onClose(hashBlock, size)
 	}
 	return n, err
 }
 
-func (h *hashingReadCloser) Close() error {
+func (h *hashingReadCloser3) Close() error {
 	if !h.done {
 		h.done = true
 		buf := make([]byte, 32*1024)
 		for {
 			n, err := h.source.Read(buf)
 			if n > 0 {
-				h.hashers.write(buf[:n])
-				h.size += int64(n)
+				h.hasher.Write(buf[:n]) //nolint:errcheck
 			}
 			if err != nil {
 				break
 			}
 		}
-		h.onClose(h.size)
+		hashBlock, size := h.hasher.Finish()
+		h.onClose(hashBlock, size)
 	}
 	return h.source.Close()
+}
+
+// buildHeadersMeta creates CBOR metadata for the http-headers schema.
+// Includes non-standard headers, with auth-related values redacted.
+func buildHeadersMeta(h http.Header) []byte {
+	var headers [][]string
+	for name, values := range h {
+		if isStandardHeader(name) {
+			continue
+		}
+		for _, v := range values {
+			if isAuthHeader(name) {
+				v = "<redacted>"
+			}
+			headers = append(headers, []string{name, v})
+		}
+	}
+	if headers == nil {
+		// No interesting headers — still attach schema with empty list.
+		headers = [][]string{}
+	}
+	meta, _ := cbor.Marshal(map[string]any{"headers": headers})
+	return meta
+}
+
+var standardHeaders = map[string]bool{
+	"Content-Length":    true,
+	"Content-Type":     true,
+	"Transfer-Encoding": true,
+	"Connection":       true,
+	"Host":             true,
+	"Accept":           true,
+	"Accept-Encoding":  true,
+	"Accept-Language":  true,
+	"Cache-Control":    true,
+	"Date":             true,
+	"Server":           true,
+	"User-Agent":       true,
+	"Vary":             true,
+	"Etag":             true,
+	"Last-Modified":    true,
+	"If-Modified-Since": true,
+	"If-None-Match":    true,
+	"Content-Encoding": true,
+	"Location":         true,
+}
+
+func isStandardHeader(name string) bool {
+	return standardHeaders[http.CanonicalHeaderKey(name)]
+}
+
+var authHeaders = map[string]bool{
+	"Authorization":       true,
+	"Cookie":              true,
+	"Set-Cookie":          true,
+	"Proxy-Authorization": true,
+}
+
+func isAuthHeader(name string) bool {
+	return authHeaders[http.CanonicalHeaderKey(name)]
 }


### PR DESCRIPTION
Covered in previous feedback, the network isolation is incomplete due to the way the iptables rules are set up and the availability of iptables -F to potentially bypass the relay.  This change ensures the relay is no longer able to be bypassed in a functional manner (i.e. doing so doesn't exfiltrate requests in any way).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
