### PR TITLE
feat: Add warden-io binary, eliminate curl dependency

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,8 @@
 version: 2
 project_name: buildwarden
+before:
+  hooks:
+    - cmd: sh -c 'GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/warden-io-linux-amd64 ./cmd/warden-io && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/warden-io-linux-arm64 ./cmd/warden-io'
 builds:
   - id: warden
     main: ./cmd/warden
@@ -13,6 +16,12 @@ archives:
   - id: default
     builds: [warden]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - src: dist/warden-io-linux-{{ .Arch }}
+        dst: .
+        info:
+          name: warden-io
+          mode: 0755
 checksum:
   name_template: checksums.txt
   algorithm: sha256

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 build:
 	go build -o warden ./cmd/warden/
 	GOOS=linux CGO_ENABLED=0 go build -o warden-relay ./cmd/relay/
+	GOOS=linux CGO_ENABLED=0 go build -o warden-io ./cmd/warden-io/
 
 test:
 	go test ./...
@@ -24,4 +25,4 @@ cover:
 	go tool cover -func=coverage.out
 
 clean:
-	rm -f warden warden-relay coverage.out
+	rm -f warden warden-relay warden-io coverage.out

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Every request is individually hashed (BLAKE2b + SHA-256 + SHA-1 + MD5) and signe
 2. The relay intercepts TLS with a per-build ephemeral CA (injected into the container's trust store). It forwards requests upstream, verifying the real server certificates.
 3. Every request/response pair is hashed and signed into the ledger in real time. The signature chain ensures records cannot be reordered, inserted, or removed without detection.
 4. Source files enter the build exclusively through the relay (Dockerfile `COPY` directives are rewritten to fetch via HTTP), giving full provenance over local files too.
-5. Build outputs can be posted back to the ledger as artifacts (`curl -X POST http://artifacts/<name>`), binding them to the same signature chain as their inputs.
+5. Build outputs can be posted back to the ledger as artifacts (`warden-io post <file>`), binding them to the same signature chain as their inputs.
 
 ## Package Manager Support
 

--- a/cmd/warden-io/main.go
+++ b/cmd/warden-io/main.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+	}
+
+	switch os.Args[1] {
+	case "fetch":
+		if len(os.Args) < 3 {
+			fatal("fetch requires at least one argument")
+		}
+		os.Exit(runFetch(os.Args[2:]))
+	case "post":
+		if len(os.Args) < 3 {
+			fatal("post requires a file argument")
+		}
+		os.Exit(runPost(os.Args[2:]))
+	default:
+		usage()
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Usage: warden-io <fetch|post> [args...]\n")
+	fmt.Fprintf(os.Stderr, "  fetch <file> [-o dest]  "+
+		"Fetch a context file\n")
+	fmt.Fprintf(os.Stderr, "  post <file> [name]      "+
+		"Post a build artifact\n")
+	os.Exit(1)
+}
+
+func fatal(msg string) {
+	fmt.Fprintf(os.Stderr, "warden-io: %s\n", msg)
+	os.Exit(1)
+}
+
+func runFetch(args []string) int {
+	var dest string
+	var files []string
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-o":
+			i++
+			if i >= len(args) {
+				fatal("-o requires a destination path")
+			}
+			dest = args[i]
+		default:
+			files = append(files, args[i])
+		}
+	}
+
+	if len(files) == 0 {
+		fatal("no files specified")
+	}
+
+	exitCode := 0
+	for _, f := range files {
+		out := dest
+		if out == "" {
+			out = f
+		} else if len(files) > 1 || strings.HasSuffix(out, "/") {
+			out = filepath.Join(out, filepath.Base(f))
+		}
+
+		if err := fetchFile(f, out); err != nil {
+			fmt.Fprintf(os.Stderr, "warden-io: fetch %s: %s\n", f, err)
+			exitCode = 1
+		}
+	}
+	return exitCode
+}
+
+func fetchFile(src, dest string) error {
+	if dir := filepath.Dir(dest); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+
+	resp, err := http.Get("http://cwd/" + src)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func runPost(args []string) int {
+	filePath := args[0]
+	name := filepath.Base(filePath)
+	if len(args) > 1 {
+		name = args[1]
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warden-io: %s\n", err)
+		return 1
+	}
+	defer f.Close()
+
+	resp, err := http.Post("http://artifacts/"+name, "application/octet-stream", f)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warden-io: post %s: %s\n", name, err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "warden-io: post %s: HTTP %d: %s\n",
+			name, resp.StatusCode, strings.TrimSpace(string(body)))
+		return 1
+	}
+
+	fmt.Print(string(body))
+	return 0
+}

--- a/cmd/warden/inspect_impl.go
+++ b/cmd/warden/inspect_impl.go
@@ -90,20 +90,38 @@ var channelColors = []string{
 
 const colorReset = "\033[0m"
 
+// Reserved hostname colors — visually distinct from channel rotation.
+const (
+	colorContext  = "\033[2m"        // dim (context fetches are routine plumbing)
+	colorArtifact = "\033[1;32m"     // bold green (artifacts are the valuable output)
+)
+
 type colorTracker struct {
-	openSet   map[string]int
-	nextColor int
-	useColor  bool
+	openSet      map[string]int
+	reservedSet  map[string]string // sigKey -> fixed color for reserved hosts
+	nextColor    int
+	useColor     bool
 }
 
 func newColorTracker(useColor bool) *colorTracker {
 	return &colorTracker{
-		openSet:  make(map[string]int),
-		useColor: useColor,
+		openSet:     make(map[string]int),
+		reservedSet: make(map[string]string),
+		useColor:    useColor,
 	}
 }
 
-func (ct *colorTracker) assignOpen(sigKey string) {
+func (ct *colorTracker) assignOpen(sigKey string, rec ledger.Record) {
+	if host := extractHost(rec); host != "" {
+		switch host {
+		case "cwd":
+			ct.reservedSet[sigKey] = colorContext
+			return
+		case "artifacts":
+			ct.reservedSet[sigKey] = colorArtifact
+			return
+		}
+	}
 	ct.openSet[sigKey] = ct.nextColor % len(channelColors)
 	ct.nextColor++
 }
@@ -111,6 +129,13 @@ func (ct *colorTracker) assignOpen(sigKey string) {
 func (ct *colorTracker) colorFor(rec ledger.Record) string {
 	if !ct.useColor {
 		return ""
+	}
+	key := string(rec.Signature)
+	if rec.Type != ledger.RecordOpen {
+		key = string(rec.OpenSig)
+	}
+	if c, ok := ct.reservedSet[key]; ok {
+		return c
 	}
 	if rec.Type == ledger.RecordOpen {
 		return channelColors[ct.openSet[string(rec.Signature)]]
@@ -123,10 +148,40 @@ func (ct *colorTracker) colorFor(rec ledger.Record) string {
 	return channelColors[0]
 }
 
+func (ct *colorTracker) isReserved(rec ledger.Record) bool {
+	key := string(rec.Signature)
+	if rec.Type != ledger.RecordOpen {
+		key = string(rec.OpenSig)
+	}
+	_, ok := ct.reservedSet[key]
+	return ok
+}
+
 func (ct *colorTracker) closeChannel(rec ledger.Record) {
 	if rec.OpenSig != nil {
 		delete(ct.openSet, string(rec.OpenSig))
+		delete(ct.reservedSet, string(rec.OpenSig))
 	}
+}
+
+func extractHost(rec ledger.Record) string {
+	if rec.Metadata == nil {
+		return ""
+	}
+	var m map[string]any
+	if err := cbor.Unmarshal(rec.Metadata, &m); err != nil {
+		return ""
+	}
+	url, _ := m["url"].(string)
+	if url == "" {
+		return ""
+	}
+	url = strings.TrimPrefix(url, "http://")
+	url = strings.TrimPrefix(url, "https://")
+	if i := strings.IndexAny(url, ":/"); i >= 0 {
+		return url[:i]
+	}
+	return url
 }
 
 func printHuman(
@@ -158,7 +213,7 @@ func printHuman(
 
 		if verbosity >= 1 {
 			printEntryTree(
-				w, i, rec, ct.colorFor(rec), ct.useColor, verbosity, schemas,
+				w, i, rec, ct.colorFor(rec), ct.useColor, verbosity, schemas, ct,
 			)
 			if rec.Type == ledger.RecordClose || rec.Type == ledger.RecordArtifact {
 				ct.closeChannel(rec)
@@ -168,7 +223,7 @@ func printHuman(
 
 	if verbosity == 0 {
 		for _, ch := range ordered {
-			printCompact(w, ch)
+			printCompact(w, ch, noColor)
 		}
 	}
 
@@ -184,7 +239,7 @@ func groupRecord(
 		ch := &channel{open: rec}
 		channels[sigKey] = ch
 		ordered = append(ordered, ch)
-		ct.assignOpen(sigKey)
+		ct.assignOpen(sigKey, rec)
 	case ledger.RecordCheckpoint:
 		if ch, ok := channels[string(rec.OpenSig)]; ok {
 			ch.checkpoints = append(ch.checkpoints, rec)
@@ -385,6 +440,7 @@ func verifyHeader(h ledger.Header) bool {
 func printEntryTree(
 	w io.Writer, seq int, r ledger.Record,
 	color string, useColor bool, verbosity int, schemas []string,
+	ct *colorTracker,
 ) {
 	check := "✅"
 	reset := ""
@@ -408,11 +464,17 @@ func printEntryTree(
 		schemaLabel = fmt.Sprintf(" [%s]", schemaShortName(s))
 	}
 
+	reserved := ct.isReserved(r)
+
 	switch r.Type {
 	case ledger.RecordOpen:
 		meta := metaSummary(r)
-		fmt.Fprintf(w, "[%3d] %s %sOPEN %s%s%s%s\n",
-			seq+1, check, color, meta, schemaLabel, sigLabel, reset)
+		typeLabel := "OPEN"
+		if reserved {
+			typeLabel = reservedTypeLabel(r)
+		}
+		fmt.Fprintf(w, "[%3d] %s %s%s %s%s%s%s\n",
+			seq+1, check, color, typeLabel, meta, schemaLabel, sigLabel, reset)
 	case ledger.RecordCheckpoint:
 		dir := dirArrow(r.Direction())
 		openLabel := channelLabel(r.OpenSig, useColor, color)
@@ -431,6 +493,18 @@ func printEntryTree(
 		fmt.Fprintf(w, "[%3d] %s %s └─ ARTIFACT %s (%d bytes)%s%s%s%s\n",
 			seq+1, check, color, meta,
 			r.AbsPayloadSize(), schemaLabel, openLabel, sigLabel, reset)
+	}
+}
+
+func reservedTypeLabel(r ledger.Record) string {
+	host := extractHost(r)
+	switch host {
+	case "cwd":
+		return "CONTEXT"
+	case "artifacts":
+		return "ARTIFACT"
+	default:
+		return "OPEN"
 	}
 }
 
@@ -465,7 +539,7 @@ func channelLabel(openSig []byte, useColor bool, _ string) string {
 	return ""
 }
 
-func printCompact(w io.Writer, ch *channel) {
+func printCompact(w io.Writer, ch *channel, noColor bool) {
 	meta := metaSummary(ch.open)
 	status := ""
 	var size int64
@@ -477,7 +551,29 @@ func printCompact(w io.Writer, ch *channel) {
 	} else {
 		status = " UNCLOSED"
 	}
-	fmt.Fprintf(w, "✅%s %s (%d bytes)\n", status, meta, size)
+
+	host := extractHost(ch.open)
+	prefix := ""
+	suffix := ""
+	if !noColor {
+		switch host {
+		case "cwd":
+			prefix = colorContext
+			suffix = colorReset
+			if status == "" {
+				status = " CONTEXT"
+			}
+		case "artifacts":
+			prefix = colorArtifact
+			suffix = colorReset
+		}
+	} else {
+		if host == "cwd" && status == "" {
+			status = " CONTEXT"
+		}
+	}
+
+	fmt.Fprintf(w, "%s✅%s %s (%d bytes)%s\n", prefix, status, meta, size, suffix)
 }
 
 func metaSummary(r ledger.Record) string {
@@ -492,12 +588,22 @@ func metaSummary(r ledger.Record) string {
 	url, _ := m["url"].(string)
 	name, _ := m["name"].(string)
 	if method != "" && url != "" {
-		return fmt.Sprintf("%s %s", method, url)
+		return fmt.Sprintf("%s %s", method, friendlyURL(url))
 	}
 	if name != "" {
 		return fmt.Sprintf("→ %s", name)
 	}
 	return ""
+}
+
+func friendlyURL(url string) string {
+	if strings.HasPrefix(url, "http://cwd/") {
+		return strings.TrimPrefix(url, "http://cwd")
+	}
+	if strings.HasPrefix(url, "http://artifacts/") {
+		return strings.TrimPrefix(url, "http://artifacts")
+	}
+	return url
 }
 
 func dirArrow(dir string) string {

--- a/cmd/warden/orchestrator.go
+++ b/cmd/warden/orchestrator.go
@@ -154,6 +154,10 @@ func (d *CtrEnv) createBuildEnv() error {
 		return fmt.Errorf("error creating %s: %w", d.wardenDirPath(), err)
 	}
 
+	if err := d.buildWardenIO(); err != nil {
+		return err
+	}
+
 	d.buildId = randanum(8)
 	log.Info(fmt.Sprintf("Build ID: %s", d.buildId))
 
@@ -238,6 +242,31 @@ func (d *CtrEnv) pullRelayImage() error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error pulling relay image %s: %w",
 			d.relayImage, err)
+	}
+	return nil
+}
+
+func (d *CtrEnv) buildWardenIO() error {
+	dest := filepath.Join(d.wardenDirPath(), "warden-io")
+
+	// In release mode, look for warden-io next to the warden binary.
+	if version != "dev" {
+		exe, err := os.Executable()
+		if err == nil {
+			candidate := filepath.Join(filepath.Dir(exe), "warden-io")
+			if data, err := os.ReadFile(candidate); err == nil {
+				return os.WriteFile(dest, data, 0755)
+			}
+		}
+	}
+
+	// Dev mode: cross-compile from source.
+	cmd := exec.Command("go", "build", "-o", dest, "./cmd/warden-io")
+	cmd.Env = append(os.Environ(), "GOOS=linux", "CGO_ENABLED=0")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error cross-compiling warden-io: %w", err)
 	}
 	return nil
 }
@@ -719,7 +748,8 @@ func (d *CtrEnv) editContainerfile() error {
 			}
 			_, _ = ctrfile.WriteString("COPY .warden /.warden\n")
 			_, _ = ctrfile.WriteString(
-				"RUN find /.warden/ext.d/ -exec sh {} \\;\n")
+				"RUN ln -sf /.warden/warden-io /usr/local/bin/warden-io" +
+					" && find /.warden/ext.d/ -exec sh {} \\;\n")
 			continue
 		}
 
@@ -802,11 +832,10 @@ func buildFetchRun(files []string, dest string) string {
 		dir := dest[:strings.LastIndex(dest, "/")+1]
 		if dir != "" {
 			return fmt.Sprintf(
-				"RUN mkdir -p %s && curl -fsSL -o %s \"http://cwd/%s\"",
-				dir, dest, files[0])
+				"RUN mkdir -p %s && warden-io fetch %s -o %s",
+				dir, files[0], dest)
 		}
-		return fmt.Sprintf(
-			"RUN curl -fsSL -o %s \"http://cwd/%s\"", dest, files[0])
+		return fmt.Sprintf("RUN warden-io fetch %s -o %s", files[0], dest)
 	}
 
 	d := dest
@@ -821,7 +850,7 @@ func buildFetchRun(files []string, dest string) string {
 	fmt.Fprintf(&sb,
 		" | \\\n    xargs -P8 -I{} sh -c "+
 			"'mkdir -p \"%s$(dirname \"{}\")\" && "+
-			"curl -fsSL -o \"%s{}\" \"http://cwd/{}\"'",
+			"warden-io fetch \"{}\" -o \"%s{}\"'",
 		d, d)
 	return sb.String()
 }

--- a/cmd/warden/orchestrator_test.go
+++ b/cmd/warden/orchestrator_test.go
@@ -106,7 +106,7 @@ func TestParseCopyFlags_SimpleArgs(t *testing.T) {
 
 func TestBuildFetchRun_SingleFileToFile(t *testing.T) {
 	got := buildFetchRun([]string{"main.go"}, "/app/main.go")
-	want := `RUN mkdir -p /app/ && curl -fsSL -o /app/main.go "http://cwd/main.go"`
+	want := `RUN mkdir -p /app/ && warden-io fetch main.go -o /app/main.go`
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)
 	}
@@ -115,7 +115,7 @@ func TestBuildFetchRun_SingleFileToFile(t *testing.T) {
 func TestBuildFetchRun_SingleFileToFileNested(t *testing.T) {
 	// Single file to a non-dir dest with no directory component.
 	got := buildFetchRun([]string{"app.bin"}, "app.bin")
-	want := `RUN curl -fsSL -o app.bin "http://cwd/app.bin"`
+	want := `RUN warden-io fetch app.bin -o app.bin`
 	if got != want {
 		t.Errorf("got:\n%s\nwant:\n%s", got, want)
 	}

--- a/docs/book/src/concepts/copy-provenance.md
+++ b/docs/book/src/concepts/copy-provenance.md
@@ -6,7 +6,7 @@ Docker `COPY` directives introduce build inputs that traditionally bypass networ
 
 1. The orchestrator mounts the build context into the relay container (read-only)
 2. The relay serves these files at `http://cwd/<path>`
-3. `COPY` directives in the Dockerfile are rewritten to `RUN curl` commands that fetch each file from the relay
+3. `COPY` directives in the Dockerfile are rewritten to `RUN warden-io fetch` commands that fetch each file from the relay
 4. Each file transfer creates a ledger entry with full hash verification
 
 ## Example Transformation
@@ -19,10 +19,10 @@ COPY src/ /app/src/
 
 What actually runs:
 ```dockerfile
-RUN mkdir -p /app/ && curl -fsSL -o /app/requirements.txt "http://cwd/requirements.txt"
+RUN mkdir -p /app/ && warden-io fetch requirements.txt -o /app/requirements.txt
 RUN mkdir -p /app/src/ && \
     printf '%s\n' 'src/main.py' 'src/lib.py' 'src/utils.py' | \
-    xargs -P8 -I{} sh -c 'mkdir -p "/app/src/$(dirname "{}")" && curl -fsSL -o "/app/src/{}" "http://cwd/{}"'
+    xargs -P8 -I{} sh -c 'mkdir -p "/app/src/$(dirname "{}")" && warden-io fetch "{}" -o "/app/src/{}"'
 ```
 
 ## What Gets Excluded
@@ -66,9 +66,9 @@ This produces a single ledger entry for the tarball rather than thousands of ind
 
 Source file entries appear as:
 ```
-✅ GET http://cwd/src/main.py (1523 bytes)
-✅ GET http://cwd/src/lib.py (4201 bytes)
-✅ GET http://cwd/requirements.txt (42 bytes)
+✅ CONTEXT GET /src/main.py (1523 bytes)
+✅ CONTEXT GET /src/lib.py (4201 bytes)
+✅ CONTEXT GET /requirements.txt (42 bytes)
 ```
 
 Each with full blake2b_256, sha256, sha1, and md5 hashes in the hash block.

--- a/examples/Dockerfile.cryptography
+++ b/examples/Dockerfile.cryptography
@@ -7,7 +7,6 @@ FROM python:3.12-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         cargo \
-        curl \
         git \
         libffi-dev \
         libssl-dev \
@@ -31,9 +30,7 @@ RUN python -m build --wheel
 
 # Post the wheel
 RUN WHEEL=$(ls dist/cryptography-*.whl) && \
-    curl -fsSL -X POST --data-binary @"$WHEEL" \
-        "http://artifacts/$(basename $WHEEL)" && \
-    echo "Artifact posted: $(basename $WHEEL)"
+    warden-io post "$WHEEL"
 
 # Run a subset of the test suite to generate more ledger entries
 RUN python -m pytest tests/hazmat/primitives/test_hashes.py -x -q --tb=short 2>&1 | tail -5 || true

--- a/examples/Dockerfile.expanded
+++ b/examples/Dockerfile.expanded
@@ -4,7 +4,7 @@
 
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl git && \
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pip install --upgrade pip build pytest mypy
@@ -22,9 +22,7 @@ RUN python -m build --wheel
 
 # Post the built wheel as an artifact
 RUN WHEEL=$(ls dist/requests-*.whl) && \
-    curl -fsSL -X POST --data-binary @"$WHEEL" \
-        "http://artifacts/$(basename $WHEEL)" && \
-    echo "Artifact posted: $(basename $WHEEL)"
+    warden-io post "$WHEEL"
 
 # Install the built wheel + test dependencies
 RUN pip install dist/requests-*.whl && \

--- a/examples/Dockerfile.pytorch-aarch64
+++ b/examples/Dockerfile.pytorch-aarch64
@@ -132,5 +132,4 @@ RUN python -c "import torch; print(f'PyTorch {torch.__version__} CUDA={torch.cud
 
 # Post the wheel artifact to BuildWarden's artifact endpoint
 RUN WHEEL=$(ls dist/torch-*.whl) && \
-    curl -fsSL -X POST --data-binary @"$WHEEL" "http://artifacts/$(basename $WHEEL)" && \
-    echo "Artifact posted: $(basename $WHEEL)"
+    warden-io post "$WHEEL"

--- a/examples/Dockerfile.simple
+++ b/examples/Dockerfile.simple
@@ -1,8 +1,5 @@
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
 RUN pip install --upgrade pip build
 
 # Download the latest requests source distribution and build a wheel
@@ -14,6 +11,4 @@ RUN pip download --no-binary :all: --no-deps requests==2.32.3 -d /tmp/sdist && \
 
 # Post the built wheel as an artifact
 RUN WHEEL=$(ls /tmp/requests-*.whl) && \
-    curl -fsSL -X POST --data-binary @"$WHEEL" \
-        "http://artifacts/$(basename $WHEEL)" && \
-    echo "Artifact posted: $(basename $WHEEL)"
+    warden-io post "$WHEEL"

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,10 +31,10 @@ warden inspect --json /tmp/warden-ledger-*/ledger
 
 ## Adding your own
 
-Any standard Dockerfile works. To post build artifacts back to the ledger, use the reserved `artifacts` hostname:
+Any standard Dockerfile works. To post build artifacts back to the ledger, use the built-in `warden-io` tool:
 
 ```dockerfile
-RUN curl -X POST --data-binary @output.whl "http://artifacts/output.whl"
+RUN warden-io post output.whl
 ```
 
-The `.warden/` directory is automatically injected into the build context with CA certificates and extension scripts. You don't need to reference it explicitly.
+The `.warden/` directory is automatically injected into the build context with CA certificates, the `warden-io` binary, and extension scripts. The binary is symlinked into PATH — no installation required.

--- a/install.sh
+++ b/install.sh
@@ -57,9 +57,11 @@ main() {
     mkdir -p "$INSTALL_DIR"
     if [ -w "$INSTALL_DIR" ]; then
         mv "${TMP}/warden" "${INSTALL_DIR}/warden"
+        mv "${TMP}/warden-io" "${INSTALL_DIR}/warden-io"
     else
         echo "Installing to ${INSTALL_DIR} (requires sudo)..."
         sudo mv "${TMP}/warden" "${INSTALL_DIR}/warden"
+        sudo mv "${TMP}/warden-io" "${INSTALL_DIR}/warden-io"
     fi
 
     echo "Installed: ${INSTALL_DIR}/warden (${VERSION})"


### PR DESCRIPTION
## Summary

- Adds `cmd/warden-io/` — a static Linux binary with `fetch` and `post` subcommands for interacting with BuildWarden's reserved hostnames (`cwd`, `artifacts`) without needing curl installed
- Orchestrator cross-compiles and injects it into `.warden/`, symlinks to `/usr/local/bin/warden-io` so it's on PATH in build containers
- COPY rewriter now emits `warden-io fetch` instead of `curl -fsSL`
- All examples updated to use `warden-io post` — removes curl installation where it was only needed for warden
- `warden inspect` now visually distinguishes reserved hostnames: context fetches render dim with `CONTEXT` label, artifact posts render bold green with `ARTIFACT` label, and URLs show just the path
- Release packaging (goreleaser, install.sh) updated to ship `warden-io` alongside `warden`

## Test plan

- [x] `go build ./...` — all packages compile
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./...` — all tests pass (including updated `buildFetchRun` assertions)
- [ ] Integration test: run `warden build` with `Dockerfile.simple` and verify artifact posts without curl
- [ ] Verify `warden inspect` output shows CONTEXT/ARTIFACT labels with correct colors on a real ledger

🤖 Generated with [Claude Code](https://claude.com/claude-code)