### PR TITLE
fix: Resolve DNS failure when using Docker runtime on Linux

### DIFF
--- a/cmd/warden/driver_script.go
+++ b/cmd/warden/driver_script.go
@@ -384,7 +384,7 @@ func (s *ScriptEnv) startBuildContainer(image string) error {
 // of Kubernetes pod-level network namespace sharing.
 
 const netnsDockerfile = `FROM alpine:latest
-RUN apk add --no-cache iptables
+RUN apk add --no-cache iptables iptables-legacy
 ENTRYPOINT ["sh", "-c"]
 `
 
@@ -428,7 +428,14 @@ func (s *ScriptEnv) isolateBuildContainer() error {
 		return fmt.Errorf("building netns image: %w", err)
 	}
 
+	// Flush Docker's embedded DNS legacy iptables rules (DOCKER_OUTPUT chain)
+	// before applying our own. Docker on Linux injects legacy-iptables DNAT
+	// rules that redirect 127.0.0.11:53 to its embedded DNS resolver. If
+	// these remain, DNS bypasses the relay even after our nftables DNAT rules
+	// are applied (legacy and nftables are separate kernel tables).
 	script := fmt.Sprintf(`set -e
+iptables-legacy -t nat -F DOCKER_OUTPUT 2>/dev/null || true
+iptables-legacy -t nat -F DOCKER_POSTROUTING 2>/dev/null || true
 iptables -t nat -A OUTPUT -p udp --dport 53 -j DNAT --to-destination %[1]s:53
 iptables -t nat -A OUTPUT -p tcp --dport 53 -j DNAT --to-destination %[1]s:53
 iptables -t nat -A OUTPUT -p tcp --dport 80 -j DNAT --to-destination %[1]s:80
@@ -450,6 +457,17 @@ iptables -A OUTPUT -j DROP
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("network isolation failed: %w", err)
+	}
+
+	// Overwrite resolv.conf to point directly at the relay. Docker on
+	// user-defined networks ignores --dns and always sets nameserver to
+	// 127.0.0.11 (its embedded DNS). Writing the relay IP ensures DNS
+	// queries go to the relay regardless of iptables backend mismatches.
+	_, err := ctrctl.ContainerExec(nil, s.buildContainer,
+		"sh", "-c", fmt.Sprintf("echo 'nameserver %s' > /etc/resolv.conf",
+			s.subnet.relayIP))
+	if err != nil {
+		return fmt.Errorf("overwriting resolv.conf: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Docker on user-defined networks ignores --dns and always injects 127.0.0.11 (its embedded DNS) into resolv.conf. Additionally, Docker uses iptables-legacy to DNAT 127.0.0.11:53 to its DNS process, while Alpine's iptables package uses nftables — these are separate kernel tables, so the relay's DNAT rules never intercept DNS traffic.

Fix by:
1. Flushing Docker's legacy iptables DNS interception rules in the netns sidecar before applying relay DNAT rules
2. Overwriting /etc/resolv.conf in the build container to point directly at the relay IP
3. Installing iptables-legacy in the warden-netns image


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
