### PR TITLE
feat: Support custom upstream CA certificates for relay

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -63,6 +63,11 @@ func run() int {
 		return 1
 	}
 
+	if err := configureUpstreamTLS(outDir); err != nil {
+		fmt.Fprintf(os.Stderr, "error configuring upstream TLS: %v\n", err)
+		return 1
+	}
+
 	if err := DetectSelfIP(); err != nil {
 		fmt.Fprintf(os.Stderr, "error detecting relay IP: %v\n", err)
 		return 1

--- a/cmd/relay/upstream_ca.go
+++ b/cmd/relay/upstream_ca.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func configureUpstreamTLS(ledgerDir string) error {
+	pool, err := buildUpstreamCertPool(ledgerDir)
+	if err != nil {
+		return err
+	}
+	if pool != nil {
+		transport.TLSClientConfig.RootCAs = pool
+	}
+	return nil
+}
+
+func buildUpstreamCertPool(ledgerDir string) (*x509.CertPool, error) {
+	includeSystem := os.Getenv("RELAY_SYSTEM_CA") != "false"
+
+	bundlePath := filepath.Join(ledgerDir, "upstream-ca-bundle.pem")
+	data, err := os.ReadFile(bundlePath)
+	if os.IsNotExist(err) {
+		if includeSystem {
+			return nil, nil
+		}
+		fmt.Fprintf(os.Stderr,
+			"relay: WARNING: system CAs disabled and no custom bundle provided"+
+				" — all upstream HTTPS will fail\n")
+		return x509.NewCertPool(), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading upstream CA bundle: %w", err)
+	}
+
+	var pool *x509.CertPool
+	if includeSystem {
+		pool, err = x509.SystemCertPool()
+		if err != nil {
+			pool = x509.NewCertPool()
+		}
+	} else {
+		pool = x509.NewCertPool()
+	}
+
+	if !pool.AppendCertsFromPEM(data) {
+		return nil, fmt.Errorf(
+			"upstream-ca-bundle.pem: no valid certificates found")
+	}
+
+	fmt.Fprintf(os.Stderr, "relay: loaded custom upstream CA bundle (%d bytes)\n",
+		len(data))
+	return pool, nil
+}

--- a/cmd/relay/upstream_ca_test.go
+++ b/cmd/relay/upstream_ca_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testCertPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl,
+		&key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestBuildUpstreamCertPool_NoBundleFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RELAY_SYSTEM_CA", "true")
+
+	pool, err := buildUpstreamCertPool(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pool != nil {
+		t.Fatal("expected nil pool when no bundle and system CAs enabled")
+	}
+}
+
+func TestBuildUpstreamCertPool_ValidBundle(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RELAY_SYSTEM_CA", "true")
+
+	certPEM := testCertPEM(t)
+	if err := os.WriteFile(
+		filepath.Join(dir, "upstream-ca-bundle.pem"), certPEM, 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	pool, err := buildUpstreamCertPool(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pool == nil {
+		t.Fatal("expected non-nil pool")
+	}
+}
+
+func TestBuildUpstreamCertPool_InvalidBundle(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RELAY_SYSTEM_CA", "true")
+
+	if err := os.WriteFile(
+		filepath.Join(dir, "upstream-ca-bundle.pem"),
+		[]byte("not a cert"), 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := buildUpstreamCertPool(dir)
+	if err == nil {
+		t.Fatal("expected error for invalid bundle")
+	}
+}
+
+func TestBuildUpstreamCertPool_SystemDisabled(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RELAY_SYSTEM_CA", "false")
+
+	certPEM := testCertPEM(t)
+	if err := os.WriteFile(
+		filepath.Join(dir, "upstream-ca-bundle.pem"), certPEM, 0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	pool, err := buildUpstreamCertPool(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pool == nil {
+		t.Fatal("expected non-nil pool")
+	}
+}
+
+func TestBuildUpstreamCertPool_SystemDisabledNoBundle(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RELAY_SYSTEM_CA", "false")
+
+	pool, err := buildUpstreamCertPool(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pool == nil {
+		t.Fatal("expected non-nil (empty) pool, not nil")
+	}
+}

--- a/cmd/warden/build.go
+++ b/cmd/warden/build.go
@@ -6,10 +6,12 @@ type BuildEnv interface {
 }
 
 type BuildConfig struct {
-	Context       string
-	Containerfile string
-	Capture       string
-	OutputDir     string
-	Compress      bool
-	RelayImage    string
+	Context         string
+	Containerfile   string
+	Capture         string
+	OutputDir       string
+	Compress        bool
+	RelayImage      string
+	UpstreamCACerts []string
+	SystemCABundle  bool
 }

--- a/cmd/warden/config.go
+++ b/cmd/warden/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -14,8 +15,14 @@ import (
 
 type Config struct {
 	Runtime RuntimeConfig `toml:"runtime"`
-	Build   BuildCfg     `toml:"build"`
-	Output  OutputConfig `toml:"output"`
+	Relay   RelayConfig   `toml:"relay"`
+	Build   BuildCfg      `toml:"build"`
+	Output  OutputConfig  `toml:"output"`
+}
+
+type RelayConfig struct {
+	UpstreamCACerts []string `toml:"upstream_ca_certs"`
+	SystemCABundle  *bool    `toml:"system_ca_bundle"`
 }
 
 type RuntimeConfig struct {
@@ -53,6 +60,10 @@ func LoadConfig() (*Config, error) {
 	// Environment variable overrides
 	if cli := os.Getenv("WARDEN_CTR_CLI"); cli != "" {
 		cfg.Runtime.CLI = cli
+	}
+	if caCerts := os.Getenv("WARDEN_UPSTREAM_CA_CERTS"); caCerts != "" {
+		paths := strings.Split(caCerts, ":")
+		cfg.Relay.UpstreamCACerts = append(cfg.Relay.UpstreamCACerts, paths...)
 	}
 	if os.Getenv("NO_COLOR") != "" {
 		cfg.Output.Color = "never"

--- a/cmd/warden/driver_script.go
+++ b/cmd/warden/driver_script.go
@@ -165,6 +165,14 @@ func (s *ScriptEnv) setup() error {
 		return err
 	}
 
+	if err := prepareUpstreamCACerts(
+		s.ledgerDir,
+		s.buildConfig.UpstreamCACerts,
+		s.buildConfig.SystemCABundle,
+	); err != nil {
+		return err
+	}
+
 	log.Info("Allocating network...")
 	sub, err := allocateSubnet()
 	if err != nil {
@@ -522,6 +530,9 @@ func (s *ScriptEnv) startRelayContainer() error {
 	)
 	if s.buildConfig.Capture != "" && s.buildConfig.Capture != "none" {
 		args = append(args, "--env", "CAPTURE_MODE="+s.buildConfig.Capture)
+	}
+	if !s.buildConfig.SystemCABundle {
+		args = append(args, "--env", "RELAY_SYSTEM_CA=false")
 	}
 	args = append(args, s.relayImage)
 	cmd := exec.Command(args[0], args[1:]...)

--- a/cmd/warden/main.go
+++ b/cmd/warden/main.go
@@ -159,14 +159,21 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		compress = false
 	}
 
+	systemCA := true
+	if cfg.Relay.SystemCABundle != nil {
+		systemCA = *cfg.Relay.SystemCABundle
+	}
+
 	env := NewScriptEnv()
 	config := &BuildConfig{
-		Context:       contextDir,
-		Containerfile: dockerfile,
-		Capture:       capture,
-		OutputDir:     outputDir,
-		Compress:      compress,
-		RelayImage:    cfg.Runtime.RelayImage,
+		Context:         contextDir,
+		Containerfile:   dockerfile,
+		Capture:         capture,
+		OutputDir:       outputDir,
+		Compress:        compress,
+		RelayImage:      cfg.Runtime.RelayImage,
+		UpstreamCACerts: cfg.Relay.UpstreamCACerts,
+		SystemCABundle:  systemCA,
 	}
 	return env.Build(config)
 }
@@ -203,14 +210,21 @@ func runShell(cmd *cobra.Command, args []string) error {
 		compress = false
 	}
 
+	systemCA := true
+	if cfg.Relay.SystemCABundle != nil {
+		systemCA = *cfg.Relay.SystemCABundle
+	}
+
 	env := NewScriptEnv()
 	config := &BuildConfig{
-		Context:       contextDir,
-		Containerfile: dockerfile,
-		Capture:       capture,
-		OutputDir:     outputDir,
-		Compress:      compress,
-		RelayImage:    cfg.Runtime.RelayImage,
+		Context:         contextDir,
+		Containerfile:   dockerfile,
+		Capture:         capture,
+		OutputDir:       outputDir,
+		Compress:        compress,
+		RelayImage:      cfg.Runtime.RelayImage,
+		UpstreamCACerts: cfg.Relay.UpstreamCACerts,
+		SystemCABundle:  systemCA,
 	}
 	return env.Shell(config)
 }

--- a/cmd/warden/upstream_ca.go
+++ b/cmd/warden/upstream_ca.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var certExtensions = map[string]bool{
+	".pem": true,
+	".crt": true,
+	".cer": true,
+}
+
+func prepareUpstreamCACerts(
+	ledgerDir string, paths []string, includeSystem bool,
+) error {
+	if len(paths) == 0 && includeSystem {
+		return nil
+	}
+
+	var bundle []byte
+	var certCount, sourceCount int
+
+	for _, p := range paths {
+		expanded := expandHome(p)
+		info, err := os.Stat(expanded)
+		if err != nil {
+			return fmt.Errorf("upstream CA path %q: %w", p, err)
+		}
+
+		if info.IsDir() {
+			n, data, err := loadCertDir(expanded, p)
+			if err != nil {
+				return err
+			}
+			if n > 0 {
+				bundle = append(bundle, data...)
+				certCount += n
+				sourceCount++
+			}
+		} else {
+			n, data, err := loadCertFile(expanded, p)
+			if err != nil {
+				return err
+			}
+			bundle = append(bundle, data...)
+			certCount += n
+			sourceCount++
+		}
+	}
+
+	if len(bundle) == 0 {
+		return nil
+	}
+
+	bundlePath := filepath.Join(ledgerDir, "upstream-ca-bundle.pem")
+	if err := os.WriteFile(bundlePath, bundle, 0644); err != nil {
+		return fmt.Errorf("writing upstream CA bundle: %w", err)
+	}
+
+	log.Info(fmt.Sprintf(
+		"Prepared upstream CA bundle: %d certificates from %d sources",
+		certCount, sourceCount))
+	return nil
+}
+
+func loadCertDir(dir, label string) (int, []byte, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, nil, fmt.Errorf("reading CA directory %q: %w", label, err)
+	}
+	var bundle []byte
+	total := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if !certExtensions[ext] {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return 0, nil, fmt.Errorf(
+				"reading %s/%s: %w", label, entry.Name(), err)
+		}
+		n := countPEMCerts(data)
+		if n == 0 {
+			return 0, nil, fmt.Errorf(
+				"%s/%s: no valid PEM certificates found",
+				label, entry.Name())
+		}
+		bundle = appendPEM(bundle, data)
+		total += n
+	}
+	return total, bundle, nil
+}
+
+func loadCertFile(path, label string) (int, []byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, nil, fmt.Errorf("reading CA cert %q: %w", label, err)
+	}
+	n := countPEMCerts(data)
+	if n == 0 {
+		return 0, nil, fmt.Errorf("%q: no valid PEM certificates found", label)
+	}
+	return n, appendPEM(nil, data), nil
+}
+
+func appendPEM(bundle, data []byte) []byte {
+	bundle = append(bundle, data...)
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		bundle = append(bundle, '\n')
+	}
+	return bundle
+}
+
+func countPEMCerts(data []byte) int {
+	count := 0
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			count++
+		}
+	}
+	return count
+}
+
+func expandHome(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
+}

--- a/cmd/warden/upstream_ca_test.go
+++ b/cmd/warden/upstream_ca_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func generateTestCert(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template,
+		&key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestPrepareUpstreamCACerts_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	err := prepareUpstreamCACerts(dir, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = os.Stat(filepath.Join(dir, "upstream-ca-bundle.pem"))
+	if !os.IsNotExist(err) {
+		t.Fatal("expected no bundle file when no paths and system CA enabled")
+	}
+}
+
+func TestPrepareUpstreamCACerts_SingleFile(t *testing.T) {
+	ledgerDir := t.TempDir()
+	certDir := t.TempDir()
+	certPEM := generateTestCert(t)
+	certPath := filepath.Join(certDir, "ca.pem")
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := prepareUpstreamCACerts(ledgerDir, []string{certPath}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bundle, err := os.ReadFile(filepath.Join(ledgerDir, "upstream-ca-bundle.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countPEMCerts(bundle) != 1 {
+		t.Fatalf("expected 1 cert in bundle, got %d", countPEMCerts(bundle))
+	}
+}
+
+func TestPrepareUpstreamCACerts_MultipleCertsInOneFile(t *testing.T) {
+	ledgerDir := t.TempDir()
+	certDir := t.TempDir()
+	cert1 := generateTestCert(t)
+	cert2 := generateTestCert(t)
+	combined := append(cert1, cert2...)
+	certPath := filepath.Join(certDir, "bundle.pem")
+	if err := os.WriteFile(certPath, combined, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := prepareUpstreamCACerts(ledgerDir, []string{certPath}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bundle, err := os.ReadFile(filepath.Join(ledgerDir, "upstream-ca-bundle.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countPEMCerts(bundle) != 2 {
+		t.Fatalf("expected 2 certs in bundle, got %d", countPEMCerts(bundle))
+	}
+}
+
+func TestPrepareUpstreamCACerts_Directory(t *testing.T) {
+	ledgerDir := t.TempDir()
+	certDir := t.TempDir()
+
+	for _, f := range []struct {
+		name string
+		data []byte
+	}{
+		{"a.pem", generateTestCert(t)},
+		{"b.crt", generateTestCert(t)},
+		{"c.txt", []byte("not a cert")},
+	} {
+		if err := os.WriteFile(
+			filepath.Join(certDir, f.name), f.data, 0644,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	err := prepareUpstreamCACerts(ledgerDir, []string{certDir}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bundle, err := os.ReadFile(filepath.Join(ledgerDir, "upstream-ca-bundle.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countPEMCerts(bundle) != 2 {
+		t.Fatalf("expected 2 certs (skipping .txt), got %d", countPEMCerts(bundle))
+	}
+}
+
+func TestPrepareUpstreamCACerts_InvalidPEM(t *testing.T) {
+	ledgerDir := t.TempDir()
+	certDir := t.TempDir()
+	certPath := filepath.Join(certDir, "bad.pem")
+	if err := os.WriteFile(certPath, []byte("not valid PEM"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := prepareUpstreamCACerts(ledgerDir, []string{certPath}, true)
+	if err == nil {
+		t.Fatal("expected error for invalid PEM file")
+	}
+}
+
+func TestPrepareUpstreamCACerts_MissingPath(t *testing.T) {
+	ledgerDir := t.TempDir()
+	err := prepareUpstreamCACerts(ledgerDir, []string{"/nonexistent/path"}, true)
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+}
+
+func TestPrepareUpstreamCACerts_MultipleFiles(t *testing.T) {
+	ledgerDir := t.TempDir()
+	certDir := t.TempDir()
+	path1 := filepath.Join(certDir, "one.pem")
+	path2 := filepath.Join(certDir, "two.pem")
+	if err := os.WriteFile(path1, generateTestCert(t), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path2, generateTestCert(t), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := prepareUpstreamCACerts(ledgerDir, []string{path1, path2}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bundle, err := os.ReadFile(filepath.Join(ledgerDir, "upstream-ca-bundle.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if countPEMCerts(bundle) != 2 {
+		t.Fatalf("expected 2 certs, got %d", countPEMCerts(bundle))
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	got := expandHome("~/foo/bar")
+	want := filepath.Join(home, "foo/bar")
+	if got != want {
+		t.Fatalf("expandHome(~/foo/bar) = %q, want %q", got, want)
+	}
+
+	got = expandHome("/absolute/path")
+	if got != "/absolute/path" {
+		t.Fatalf("expandHome should not modify absolute paths, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `[relay]` config section with `upstream_ca_certs` (list of PEM file/directory paths) and `system_ca_bundle` (bool) options
- Orchestrator reads, validates, and bundles user-provided CA certs into the ledger volume before relay startup
- Relay loads the bundle at startup and configures its upstream `http.Transport` TLS trust pool
- When `system_ca_bundle = false`, the relay trusts only the user-supplied certs (enables minimal trust surface)
- Also supports `WARDEN_UPSTREAM_CA_CERTS` env var (colon-separated) for CI-friendly configuration

## Test plan

- [x] Unit tests for cert resolution: single file, multi-file, directory scanning, invalid PEM, missing path, multi-cert-per-file
- [x] Unit tests for relay pool construction: no bundle (default behavior), valid bundle, invalid bundle, system CAs disabled
- [x] Full test suite passes (`go test ./...`)
- [x] Lint clean (`golangci-lint run ./...`)
- [ ] Integration test with self-signed upstream HTTPS server (manual)