### PR TITLE
fix: Zero signing key on ledger finish, disable core dumps

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,8 @@ before:
         GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/warden-io-linux-arm64 ./cmd/warden-io &&
         GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/warden-io-darwin-arm64 ./cmd/warden-io &&
         GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/warden-relay-linux-amd64 ./cmd/relay &&
-        GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/warden-relay-linux-arm64 ./cmd/relay
+        GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/warden-relay-linux-arm64 ./cmd/relay &&
+        GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o dist/warden-relay-darwin-arm64 ./cmd/relay
 builds:
   - id: warden
     main: ./cmd/warden
@@ -36,6 +37,10 @@ archives:
           mode: 0755
       - src: dist/warden-io-darwin-arm64
         dst: warden-io-darwin-arm64
+        info:
+          mode: 0755
+      - src: dist/warden-relay-darwin-arm64
+        dst: warden-relay-darwin-arm64
         info:
           mode: 0755
 checksum:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build:
 ifeq ($(UNAME_S),Darwin)
 ifeq ($(UNAME_M),arm64)
 	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o dist/warden-io-darwin-arm64 ./cmd/warden-io/
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o dist/warden-relay-darwin-arm64 ./cmd/relay/
 	@$(MAKE) sign
 endif
 endif

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -14,6 +14,9 @@ func main() {
 }
 
 func run() int {
+	// Prevent key material from appearing in core dumps.
+	_ = unix.Setrlimit(unix.RLIMIT_CORE, &unix.Rlimit{Cur: 0, Max: 0})
+
 	mode := flag.String("mode", "",
 		"Relay mode: 'host', 'vm', or 'container' (auto-detected if empty)")
 	fdNum := flag.Int("fd", 3,

--- a/relay/ledger.go
+++ b/relay/ledger.go
@@ -34,6 +34,7 @@ const (
 // All writes are serialized through a single channel.
 type Ledger struct {
 	key           ed25519.PrivateKey
+	pubKey        ed25519.PublicKey
 	writer        io.Writer
 	entries       chan entryRequest
 	done          chan struct{}
@@ -98,8 +99,14 @@ func NewLedger(cfg LedgerConfig) (*Ledger, error) {
 		hashBlockSize += hashOutputSize(name)
 	}
 
+	pubKey, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("unexpected public key type")
+	}
+
 	l := &Ledger{
 		key:           priv,
+		pubKey:        pubKey,
 		writer:        cfg.Writer,
 		entries:       make(chan entryRequest, 256),
 		done:          make(chan struct{}),
@@ -118,12 +125,9 @@ func NewLedger(cfg LedgerConfig) (*Ledger, error) {
 }
 
 // PublicKey returns the raw Ed25519 public key bytes.
+// Safe to call after Finish() (the public key is retained).
 func (l *Ledger) PublicKey() ed25519.PublicKey {
-	pub, ok := l.key.Public().(ed25519.PublicKey)
-	if !ok {
-		panic("unexpected key type")
-	}
-	return pub
+	return l.pubKey
 }
 
 // Open writes an open record synchronously and returns its signature.
@@ -193,9 +197,13 @@ func (l *Ledger) Artifact(
 }
 
 // Finish drains the entry channel and waits for the loop to exit.
+// The signing key is zeroed after all writes complete.
 func (l *Ledger) Finish() {
 	close(l.entries)
 	<-l.done
+	for i := range l.key {
+		l.key[i] = 0
+	}
 }
 
 // ComputeHashBlock computes the concatenated hash block for data.


### PR DESCRIPTION
## Summary

- Zero the Ed25519 private key immediately after `Finish()` so it doesn't persist in heap memory beyond the build's lifetime
- Set `RLIMIT_CORE=0` at relay startup to prevent key material appearing in core dumps (works on both Linux and macOS host-mode relay)
- Store the public key in a separate field at creation so `PublicKey()` remains usable after key zeroing
- Add `darwin/arm64` relay binary to Makefile and goreleaser (needed for VZ host-mode relay on macOS)

## Context

Addresses the threat vectors outlined in #53. The primary mitigations are:

1. **Reduced exposure window**: Key is zeroed as soon as the last record is written, rather than lingering until process exit
2. **Core dump prevention**: Explicit `RLIMIT_CORE=0` at relay startup, regardless of container runtime defaults
3. **macOS relay build**: The VZ driver runs the relay as a host process on macOS — needs a darwin/arm64 binary in releases

## Test plan

- [x] `make test` passes (relay ledger tests verify key zeroing doesn't break signature verification)
- [x] `golangci-lint run` clean
- [x] Builds for linux/{amd64,arm64} and darwin/arm64
- [x] Verify `RLIMIT_CORE` takes effect: `cat /proc/self/limits | grep core` shows 0 inside relay container

Closes #53